### PR TITLE
Update minSdk to 24

### DIFF
--- a/combustion-android-ble/build.gradle
+++ b/combustion-android-ble/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 31
 
     defaultConfig {
-        minSdk 28
+        minSdk 24
         targetSdk 31
         versionCode 1
         versionName "0.0.3"

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeAdvertisingData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeAdvertisingData.kt
@@ -82,8 +82,8 @@ internal data class ProbeAdvertisingData (
             val probeTemperatures = ProbeTemperatures.fromRawData(manufacturerData.copyOf().sliceArray(TEMPERATURE_RANGE))
 
             // API level 26 (Andoird 8) and Higher
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                return ProbeAdvertisingData(
+            return if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                ProbeAdvertisingData(
                     name = advertisement.name ?: "Unknown",
                     mac = advertisement.address,
                     rssi = advertisement.rssi,
@@ -94,7 +94,7 @@ internal data class ProbeAdvertisingData (
                 )
             // Lower than API level 26, always return true for isConnectable
             } else {
-                return ProbeAdvertisingData(
+                ProbeAdvertisingData(
                     name = advertisement.name ?: "Unknown",
                     mac = advertisement.address,
                     rssi = advertisement.rssi,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeAdvertisingData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeAdvertisingData.kt
@@ -27,6 +27,7 @@
  */
 package inc.combustion.framework.ble
 
+import android.os.Build
 import android.bluetooth.le.ScanResult
 import com.juul.kable.Advertisement
 import inc.combustion.framework.service.ProbeTemperatures
@@ -80,15 +81,30 @@ internal data class ProbeAdvertisingData (
 
             val probeTemperatures = ProbeTemperatures.fromRawData(manufacturerData.copyOf().sliceArray(TEMPERATURE_RANGE))
 
-            return ProbeAdvertisingData(
-                name = advertisement.name ?: "Unknown",
-                mac = advertisement.address,
-                rssi = advertisement.rssi,
-                serialNumber,
-                type,
-                isConnectable = scanResult?.isConnectable ?: false,
-                probeTemperatures
-            )
+            // API level 26 (Andoird 8) and Higher
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                return ProbeAdvertisingData(
+                    name = advertisement.name ?: "Unknown",
+                    mac = advertisement.address,
+                    rssi = advertisement.rssi,
+                    serialNumber,
+                    type,
+                    isConnectable = scanResult?.isConnectable ?: false,
+                    probeTemperatures
+                )
+            // Lower than API level 26, always return true for isConnectable
+            } else {
+                return ProbeAdvertisingData(
+                    name = advertisement.name ?: "Unknown",
+                    mac = advertisement.address,
+                    rssi = advertisement.rssi,
+                    serialNumber,
+                    type,
+                    isConnectable = true,
+                    probeTemperatures
+                )
+            }
+
         }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/DataClasses.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/DataClasses.kt
@@ -27,11 +27,15 @@
  */
 package inc.combustion.framework.log
 
+
+import android.os.Build
 import inc.combustion.framework.service.ProbeUploadState
+import java.text.SimpleDateFormat
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.*
 
 /**
  * Range range data object
@@ -131,13 +135,25 @@ internal data class SessionId(val seqNumber: UInt, val id: Long = create()) : Co
 
     override fun toString(): String {
         // convert to date string in UTC
-        val timestamp = formatter.format(
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+            val timestamp = formatter.format(
                 LocalDateTime.ofInstant(
                     Instant.ofEpochMilli(id),
                     ZoneId.of("UTC")
                 )
             )
-        return timestamp + "_$seqNumber"
+            return timestamp + "_$seqNumber"
+        } else {
+            val format = "yyyy-MMM-dd HH:mm:ss"
+            val dateFormatGmt = SimpleDateFormat(format)
+            dateFormatGmt.setTimeZone(TimeZone.getTimeZone("GMT"))
+            val dateFormatLocal = SimpleDateFormat(format);
+            val timestamp = dateFormatLocal.parse(dateFormatGmt.format(Date()))
+            // return time in milliseconds and then return string to make
+            return timestamp.getTime().toString() + "_$seqNumber"
+
+        }
     }
 
     companion object {
@@ -146,6 +162,5 @@ internal data class SessionId(val seqNumber: UInt, val id: Long = create()) : Co
             // use timestamp for session ID.
             return System.currentTimeMillis()
         }
-        private val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
     }
 }


### PR DESCRIPTION
updated minSdk to 24 which uncovered a couple API incompatibilities. 

- There was a bluetooth isScannable method that was introduced in API 26, to handle this we just return true for API versions less than 26
- There are several time/date/formatting methods that were added in Java 8 that we were using. To work around that I am using some older java.util and java.text modules to create some timestamps for session id creation.  

There are some issues testing this min version with our app in a emulator currently. 