### PR TITLE
Instant Read, Probe ID, Probe Color, Timer Support

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/BitFunctions.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/BitFunctions.kt
@@ -1,6 +1,6 @@
 /*
  * Project: Combustion Inc. Android Framework
- * File: Probe.kt
+ * File: BitFunctions.kt
  * Author: https://github.com/miwright2
  *
  * MIT License
@@ -25,44 +25,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package inc.combustion.framework.service
+package inc.combustion.framework.ble
 
-/**
- * Data class for the current state of a probe.
- *
- * @property serialNumber Serial Number
- * @property mac Bluetooth MAC Address
- * @property fwVersion Firmware Version
- * @property hwRevision Hardware Revision
- * @property temperatures Current temperature values
- * @property rssi Received signal strength
- * @property minSequence Minimum log sequence number
- * @property maxSequence Current sequence number
- * @property connectionState Connection state
- * @property uploadState Upload State
- * @property id Probe ID
- * @property color Probe Color
- * @property mode Probe Mode
- *
- * @see DeviceConnectionState
- * @see ProbeUploadState
- * @see ProbeTemperatures
- * @see ProbeID
- * @see ProbeColor
- * @see ProbeMode
- */
-data class Probe(
-    val serialNumber: String,
-    val mac: String,
-    val fwVersion: String?,
-    val hwRevision: String?,
-    val temperatures: ProbeTemperatures,
-    val rssi: Int,
-    val minSequence: UInt,
-    val maxSequence: UInt,
-    val connectionState: DeviceConnectionState,
-    val uploadState: ProbeUploadState,
-    val id: ProbeID,
-    val color: ProbeColor,
-    val mode: ProbeMode
-)
+infix fun UShort.shl(shift: Int) = ((this.toInt() shl shift) and (0x0000FFFF)).toUShort()
+infix fun UShort.shr(shift: Int) = ((this.toInt() shr shift) and (0x0000FFFF)).toUShort()
+

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/Device.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/Device.kt
@@ -86,6 +86,8 @@ internal open class Device (
     private val jobList = mutableListOf<Job>()
 
     protected val monitor = IdleMonitor()
+    protected val instantReadMonitor = IdleMonitor()
+
     protected var peripheral: Peripheral =
         owner.lifecycleScope.peripheral(adapter.getRemoteDevice(mac)) {
             logging {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DeviceStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DeviceStatus.kt
@@ -27,6 +27,9 @@
  */
 package inc.combustion.framework.ble
 
+import inc.combustion.framework.service.ProbeColor
+import inc.combustion.framework.service.ProbeID
+import inc.combustion.framework.service.ProbeMode
 import inc.combustion.framework.service.ProbeTemperatures
 
 /**
@@ -39,12 +42,16 @@ import inc.combustion.framework.service.ProbeTemperatures
 internal data class DeviceStatus(
     val minSequenceNumber: UInt,
     val maxSequenceNumber: UInt,
-    val temperatures: ProbeTemperatures
+    val temperatures: ProbeTemperatures,
+    val id: ProbeID,
+    val color: ProbeColor,
+    val mode: ProbeMode
 ) {
     companion object {
         private const val MIN_SEQ_INDEX = 0
         private const val MAX_SEQ_INDEX = 4
         private val TEMPERATURE_RANGE = 8..20
+        private val MODE_COLOR_ID_RANGE = 21..21
 
         fun fromRawData(data: UByteArray): DeviceStatus? {
             if (data.size < 21) return null
@@ -52,8 +59,19 @@ internal data class DeviceStatus(
             val minSequenceNumber = data.getLittleEndianUIntAt(MIN_SEQ_INDEX)
             val maxSequenceNumber = data.getLittleEndianUIntAt(MAX_SEQ_INDEX)
             val temperatures = ProbeTemperatures.fromRawData(data.sliceArray(TEMPERATURE_RANGE))
+            val modeColorId = data.sliceArray(MODE_COLOR_ID_RANGE)[0]
+            val probeID = ProbeID.fromUByte(modeColorId)
+            val probeColor = ProbeColor.fromUByte(modeColorId)
+            val probeMode = ProbeMode.fromUByte(modeColorId)
 
-            return DeviceStatus(minSequenceNumber, maxSequenceNumber, temperatures)
+            return DeviceStatus(
+                minSequenceNumber,
+                maxSequenceNumber,
+                temperatures,
+                probeID,
+                probeColor,
+                probeMode
+            )
         }
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DeviceStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DeviceStatus.kt
@@ -59,10 +59,16 @@ internal data class DeviceStatus(
             val minSequenceNumber = data.getLittleEndianUIntAt(MIN_SEQ_INDEX)
             val maxSequenceNumber = data.getLittleEndianUIntAt(MAX_SEQ_INDEX)
             val temperatures = ProbeTemperatures.fromRawData(data.sliceArray(TEMPERATURE_RANGE))
-            val modeColorId = data.sliceArray(MODE_COLOR_ID_RANGE)[0]
-            val probeID = ProbeID.fromUByte(modeColorId)
-            val probeColor = ProbeColor.fromUByte(modeColorId)
-            val probeMode = ProbeMode.fromUByte(modeColorId)
+
+            // use mode and color ID if available
+            val modeColorId = if (data.size > 21)
+               data.sliceArray(MODE_COLOR_ID_RANGE)[0]
+            else
+                null
+
+            val probeColor = if(modeColorId != null) ProbeColor.fromUByte(modeColorId) else ProbeColor.COLOR1
+            val probeID = if(modeColorId != null) ProbeID.fromUByte(modeColorId) else ProbeID.ID1
+            val probeMode = if(modeColorId != null) ProbeMode.fromUByte(modeColorId) else ProbeMode.Normal
 
             return DeviceStatus(
                 minSequenceNumber,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeAdvertisingData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeAdvertisingData.kt
@@ -90,10 +90,15 @@ internal data class ProbeAdvertisingData (
                 manufacturerData.copyOf().sliceArray(TEMPERATURE_RANGE)
             )
 
-            val modeColorId = manufacturerData.copyOf().sliceArray(MODE_COLOR_ID_RANGE)[0]
-            val probeColor = ProbeColor.fromUByte(modeColorId)
-            val probeID = ProbeID.fromUByte(modeColorId)
-            val probeMode = ProbeMode.fromUByte(modeColorId)
+            // use mode and color ID if available
+            val modeColorId = if (manufacturerData.size > 18)
+                manufacturerData.copyOf().sliceArray(MODE_COLOR_ID_RANGE)[0]
+            else
+                null
+
+            val probeColor = if(modeColorId != null) ProbeColor.fromUByte(modeColorId) else ProbeColor.COLOR1
+            val probeID = if(modeColorId != null) ProbeID.fromUByte(modeColorId) else ProbeID.ID1
+            val probeMode = if(modeColorId != null) ProbeMode.fromUByte(modeColorId) else ProbeMode.Normal
 
             // API level 26 (Android 8) and Higher
             return if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -349,6 +349,9 @@ internal open class ProbeManager (
         val minSeq = deviceStatus?.minSequenceNumber ?: 0u
         val maxSeq = deviceStatus?.maxSequenceNumber ?: 0u
         val rssi  = if(isConnected.get()) remoteRssi.get() else advertisingData.rssi
+        val id = deviceStatus?.id ?: advertisingData.id
+        val color = deviceStatus?.color ?: advertisingData.color
+        val mode = deviceStatus?.mode ?: advertisingData.mode
 
         return Probe(
             advertisingData.serialNumber,
@@ -360,7 +363,10 @@ internal open class ProbeManager (
             minSeq,
             maxSeq,
             connectionState,
-            uploadState
+            uploadState,
+            id,
+            color,
+            mode
         )
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/SimulatedProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/SimulatedProbeManager.kt
@@ -30,6 +30,9 @@ package inc.combustion.framework.ble
 import android.bluetooth.BluetoothAdapter
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import inc.combustion.framework.service.ProbeColor
+import inc.combustion.framework.service.ProbeID
+import inc.combustion.framework.service.ProbeMode
 import inc.combustion.framework.service.ProbeTemperatures
 import kotlinx.coroutines.launch
 import kotlin.concurrent.fixedRateTimer
@@ -74,7 +77,10 @@ internal class SimulatedProbeManager (
                 fakeSerialNumber,
                 ProbeAdvertisingData.CombustionProductType.PROBE,
                 true,
-                ProbeTemperatures.withRandomData()
+                ProbeTemperatures.withRandomData(),
+                ProbeID.ID1,
+                ProbeColor.COLOR1,
+                ProbeMode.Normal
             )
 
             return SimulatedProbeManager(SIMULATED_MAC, owner, data, adapter)
@@ -123,7 +129,10 @@ internal class SimulatedProbeManager (
             advertisingData.serialNumber,
             ProbeAdvertisingData.CombustionProductType.PROBE,
             true,
-            ProbeTemperatures.withRandomData()
+            ProbeTemperatures.withRandomData(),
+            ProbeID.ID1,
+            ProbeColor.COLOR1,
+            ProbeMode.Normal
         )
 
         super.onNewAdvertisement(data)
@@ -137,7 +146,14 @@ internal class SimulatedProbeManager (
         maxSequence += 1u
 
         _deviceStatusFlow.emit(
-            DeviceStatus(0u, maxSequence, ProbeTemperatures.withRandomData())
+            DeviceStatus(
+                0u,
+                maxSequence,
+                ProbeTemperatures.withRandomData(),
+                ProbeID.ID1,
+                ProbeColor.COLOR1,
+                ProbeMode.Normal
+            )
         )
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -228,6 +228,10 @@ internal class LogManager {
         }
     }
 
+    fun recordsDownloaded(serialNumber: String): Int {
+        return temperatureLogs[serialNumber]?.dataPointCount ?: 0
+    }
+
     fun exportLogsForDevice(serialNumber: String): List<LoggedProbeDataPoint>? {
         return temperatureLogs[serialNumber]?.dataPoints
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -33,11 +33,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import inc.combustion.framework.LOG_TAG
-import inc.combustion.framework.service.DeviceConnectionState
 import inc.combustion.framework.ble.ProbeManager
-import inc.combustion.framework.service.DebugSettings
-import inc.combustion.framework.service.LoggedProbeDataPoint
-import inc.combustion.framework.service.ProbeUploadState
+import inc.combustion.framework.service.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -114,6 +111,10 @@ internal class LogManager {
                                 // do nothing, wait for the client to request the transfer
                             }
                             is ProbeUploadState.ProbeUploadInProgress -> {
+                                // only log normal mode packets
+                                if(deviceStatus.mode != ProbeMode.Normal)
+                                    return@collect
+
                                 // add device status data points to the log while the upload
                                 // is in progress.  don't event the status, because we will
                                 // do that below in processing the log response.
@@ -267,6 +268,10 @@ internal class LogManager {
                             probe.probe.uploadState !is ProbeUploadState.ProbeUploadComplete)  {
                                 throw CancellationException("Upload State is Now Invalid")
                         }
+
+                        // only log normal mode packets
+                        if(deviceStatus.mode != ProbeMode.Normal)
+                            return@collect
 
                         emit(LoggedProbeDataPoint.fromDeviceStatus(sessionId, deviceStatus))
                     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -36,9 +36,7 @@ import inc.combustion.framework.LOG_TAG
 import inc.combustion.framework.ble.ProbeManager
 import inc.combustion.framework.service.*
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.*
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -79,106 +77,124 @@ internal class LogManager {
             // monitor this probes state flow
             probeManager.addJob(owner.lifecycleScope.launch {
                 owner.repeatOnLifecycle(Lifecycle.State.CREATED) {
-                    probeManager.probeStateFlow.collect {
-
-                        // if device is disconnected, uploading is unavailable, so update
-                        // the state if it hs not already been updated and let the log know
-                        // to expect another log request at some point in the future, for its
-                        // internal bookkeeping.
-                        if(it.connectionState != DeviceConnectionState.CONNECTED
-                            && probeManager.probe.uploadState != ProbeUploadState.Unavailable) {
-                            probeManager.onNewUploadState(ProbeUploadState.Unavailable)
-                            temperatureLog?.expectFutureLogRequest()
+                    probeManager.probeStateFlow
+                        .onCompletion {
+                            Log.d(LOG_TAG, "Probe State Flow Complete")
                         }
+                        .catch {
+                            Log.i(LOG_TAG, "Probe State Flow Catch: $it")
+                        }
+                        .collect {
+                            // if device is disconnected, uploading is unavailable, so update
+                            // the state if it hs not already been updated and let the log know
+                            // to expect another log request at some point in the future, for its
+                            // internal bookkeeping.
+                            if(it.connectionState != DeviceConnectionState.CONNECTED
+                                && probeManager.probe.uploadState != ProbeUploadState.Unavailable) {
+                                probeManager.onNewUploadState(ProbeUploadState.Unavailable)
+                                temperatureLog?.expectFutureLogRequest()
+                            }
                     }
                 }
             })
             // monitor this probes device status flow
             probeManager.addJob(owner.lifecycleScope.launch {
                 owner.repeatOnLifecycle(Lifecycle.State.CREATED) {
-                    probeManager.deviceStatusFlow.collect { deviceStatus ->
-
-                        when(probeManager.probe.uploadState) {
-                            // if upload state is currently unavailable, and we now have a
-                            // DeviceStatus, then we have everything we need to start an upload.
-                            //
-                            // event the new upload state to the client, and they can initiate
-                            // the record transfer when they are ready.
-                            ProbeUploadState.Unavailable -> {
-                                probeManager.onNewUploadState(ProbeUploadState.ProbeUploadNeeded)
-                            }
-                            ProbeUploadState.ProbeUploadNeeded -> {
-                                // do nothing, wait for the client to request the transfer
-                            }
-                            is ProbeUploadState.ProbeUploadInProgress -> {
-                                // only log normal mode packets
-                                if(deviceStatus.mode != ProbeMode.Normal)
-                                    return@collect
-
-                                // add device status data points to the log while the upload
-                                // is in progress.  don't event the status, because we will
-                                // do that below in processing the log response.
-                                temperatureLog.addFromDeviceStatus(deviceStatus)
-
-                                // not receiving expected log responses, then complete the log
-                                // request and transition state.
-                                if(temperatureLog.logRequestIsStalled) {
-                                    val sessionStatus = temperatureLog.completeLogRequest()
-                                    probeManager.onNewUploadState(sessionStatus.toProbeUploadState())
-                                }
-                            }
-                            is ProbeUploadState.ProbeUploadComplete -> {
-                                if(DebugSettings.DEBUG_LOG_LOG_MANAGER_IO) {
-                                    Log.d(
-                                        LOG_TAG, "STATUS-RX : " +
-                                                "${deviceStatus.maxSequenceNumber}"
-                                    )
-                                }
-
-                                // add the device status to the temperature log
-                                val sessionStatus = temperatureLog.addFromDeviceStatus(deviceStatus)
-
-                                // if we have any dropped records then initiate a log request to
-                                // backfill from the missing records.
-                                if(sessionStatus.droppedRecords.isNotEmpty()) {
-                                    val drop = sessionStatus.droppedRecords.first()
-                                    val range = RecordRange(drop, drop)
-                                    startBackfillLogRequest(
-                                        owner, temperatureLog, probeManager, range, deviceStatus.maxSequenceNumber)
-                                }
-                                // we've synchronized the log on the device here, now maintain
-                                // the log with the data points from the device status message.
-                                // and report out the progress as part of the complete state.
-                                else {
-                                    probeManager.onNewUploadState(sessionStatus.toProbeUploadState())
-                                }
-                            }
+                    probeManager.deviceStatusFlow
+                        .onCompletion {
+                            Log.d(LOG_TAG, "Device Status Flow Complete")
                         }
+                        .catch {
+                            Log.i(LOG_TAG, "Device Status Flow Catch: $it")
+                        }
+                        .collect { deviceStatus ->
+                            when(probeManager.probe.uploadState) {
+                                // if upload state is currently unavailable, and we now have a
+                                // DeviceStatus, then we have everything we need to start an upload.
+                                //
+                                // event the new upload state to the client, and they can initiate
+                                // the record transfer when they are ready.
+                                ProbeUploadState.Unavailable -> {
+                                    probeManager.onNewUploadState(ProbeUploadState.ProbeUploadNeeded)
+                                }
+                                ProbeUploadState.ProbeUploadNeeded -> {
+                                    // do nothing, wait for the client to request the transfer
+                                }
+                                is ProbeUploadState.ProbeUploadInProgress -> {
+                                    // only log normal mode packets
+                                    if(deviceStatus.mode != ProbeMode.Normal)
+                                        return@collect
+
+                                    // add device status data points to the log while the upload
+                                    // is in progress.  don't event the status, because we will
+                                    // do that below in processing the log response.
+                                    temperatureLog.addFromDeviceStatus(deviceStatus)
+
+                                    // not receiving expected log responses, then complete the log
+                                    // request and transition state.
+                                    if(temperatureLog.logRequestIsStalled) {
+                                        val sessionStatus = temperatureLog.completeLogRequest()
+                                        probeManager.onNewUploadState(sessionStatus.toProbeUploadState())
+                                    }
+                                }
+                                is ProbeUploadState.ProbeUploadComplete -> {
+                                    if(DebugSettings.DEBUG_LOG_LOG_MANAGER_IO) {
+                                        Log.d(
+                                            LOG_TAG, "STATUS-RX : " +
+                                                    "${deviceStatus.maxSequenceNumber}"
+                                        )
+                                    }
+
+                                    // add the device status to the temperature log
+                                    val sessionStatus = temperatureLog.addFromDeviceStatus(deviceStatus)
+
+                                    // if we have any dropped records then initiate a log request to
+                                    // backfill from the missing records.
+                                    if(sessionStatus.droppedRecords.isNotEmpty()) {
+                                        val drop = sessionStatus.droppedRecords.first()
+                                        val range = RecordRange(drop, drop)
+                                        startBackfillLogRequest(
+                                            owner, temperatureLog, probeManager, range, deviceStatus.maxSequenceNumber)
+                                    }
+                                    // we've synchronized the log on the device here, now maintain
+                                    // the log with the data points from the device status message.
+                                    // and report out the progress as part of the complete state.
+                                    else {
+                                        probeManager.onNewUploadState(sessionStatus.toProbeUploadState())
+                                    }
+                                }
+                            }
                     }
                 }
             })
             // monitor this probes log response flow
             probeManager.addJob(owner.lifecycleScope.launch {
                 owner.repeatOnLifecycle(Lifecycle.State.CREATED) {
-                    probeManager.logResponseFlow.collect { response ->
-
-                        // debug log BLE IO if enabled.
-                        if(DebugSettings.DEBUG_LOG_LOG_MANAGER_IO) {
-                            Log.d(LOG_TAG, "LOG-RX    : ${response.sequenceNumber}")
+                    probeManager.logResponseFlow
+                        .onCompletion {
+                            Log.d(LOG_TAG, "Log Response Flow Complete")
                         }
-
-                        // add the response to the temperature log and handle upload progress
-                        val uploadProgress = temperatureLog.addFromLogResponse(response)
-
-                        // if we aren't complete, then update the stats of the uploading state
-                        if(!uploadProgress.isComplete) {
-                            probeManager.onNewUploadState(uploadProgress.toProbeUploadState())
+                        .catch {
+                            Log.i(LOG_TAG, "Log Response Flow Catch: $it")
                         }
-                        // otherwise complete the request, and change the state to complete
-                        else {
-                            val sessionStatus = temperatureLog.completeLogRequest()
-                            probeManager.onNewUploadState(sessionStatus.toProbeUploadState())
-                        }
+                        .collect { response ->
+                            // debug log BLE IO if enabled.
+                            if(DebugSettings.DEBUG_LOG_LOG_MANAGER_IO) {
+                                Log.d(LOG_TAG, "LOG-RX    : ${response.sequenceNumber}")
+                            }
+
+                            // add the response to the temperature log and handle upload progress
+                            val uploadProgress = temperatureLog.addFromLogResponse(response)
+
+                            // if we aren't complete, then update the stats of the uploading state
+                            if(!uploadProgress.isComplete) {
+                                probeManager.onNewUploadState(uploadProgress.toProbeUploadState())
+                            }
+                            // otherwise complete the request, and change the state to complete
+                            else {
+                                val sessionStatus = temperatureLog.completeLogRequest()
+                                probeManager.onNewUploadState(sessionStatus.toProbeUploadState())
+                            }
                     }
                 }
             })
@@ -266,18 +282,24 @@ internal class LogManager {
                     // into the flow for the consumer.  if we are no longer in an upload complete
                     // syncing state, then exit out of this flow.
                     val sessionId = log.currentSessionId
-                    probe.deviceStatusFlow.collect { deviceStatus ->
-
-                        if(probe.probe.uploadState !is ProbeUploadState.ProbeUploadInProgress &&
-                            probe.probe.uploadState !is ProbeUploadState.ProbeUploadComplete)  {
-                                throw CancellationException("Upload State is Now Invalid")
+                    probe.deviceStatusFlow
+                        .onCompletion {
+                            Log.d(LOG_TAG, "Device Status Flow Complete")
                         }
+                        .catch {
+                            Log.i(LOG_TAG, "Device Status Flow Catch: $it")
+                        }
+                        .collect { deviceStatus ->
+                            if(probe.probe.uploadState !is ProbeUploadState.ProbeUploadInProgress &&
+                                probe.probe.uploadState !is ProbeUploadState.ProbeUploadComplete)  {
+                                    throw CancellationException("Upload State is Now Invalid")
+                            }
 
-                        // only log normal mode packets
-                        if(deviceStatus.mode != ProbeMode.Normal)
-                            return@collect
+                            // only log normal mode packets
+                            if(deviceStatus.mode != ProbeMode.Normal)
+                                return@collect
 
-                        emit(LoggedProbeDataPoint.fromDeviceStatus(sessionId, deviceStatus))
+                            emit(LoggedProbeDataPoint.fromDeviceStatus(sessionId, deviceStatus))
                     }
                 }
             }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
@@ -58,6 +58,15 @@ internal class ProbeTemperatureLog(private val serialNumber: String) {
 
     val logRequestIsStalled: Boolean get() = sessions[currentSessionId]?.logRequestIsStalled ?: false
 
+    val dataPointCount: Int
+        get() {
+            var count = 0
+            sessions.forEach {
+                count += it.value.dataPointCount
+            }
+            return count
+        }
+
     fun prepareForLogRequest(deviceMinSequence: UInt, deviceMaxSequence: UInt) : RecordRange {
         var minSeq = 0u
         var maxSeq = 0u

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/Session.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/Session.kt
@@ -96,6 +96,12 @@ internal class Session(seqNum: UInt, private val serialNumber: String) {
     val dataPoints: List<LoggedProbeDataPoint>
         get() {
             return _logs.values.toList()
+
+        }
+
+    val dataPointCount: Int
+        get() {
+            return _logs.values.size
         }
 
     fun startLogRequest(range: RecordRange) : UploadProgress {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/Session.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/Session.kt
@@ -50,7 +50,7 @@ internal class Session(seqNum: UInt, private val serialNumber: String) {
          * If > than this threshold of device status packets are received, then
          * consider the log request stalled.
          */
-        const val STALE_LOG_REQUEST_PACKET_COUNT = 15u
+        const val STALE_LOG_REQUEST_PACKET_COUNT = 3u
     }
 
     private val _logs: SortedMap<UInt, LoggedProbeDataPoint> = sortedMapOf()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
@@ -259,6 +259,9 @@ class CombustionService : LifecycleService() {
     internal fun createLogFlowForDevice(serialNumber: String): Flow<LoggedProbeDataPoint> =
         LogManager.instance.createLogFlowForDevice(serialNumber)
 
+    internal fun recordsDownloaded(serialNumber: String): Int =
+        LogManager.instance.recordsDownloaded(serialNumber)
+
     internal fun clearDevices() {
         LogManager.instance.clear()
         _probes.forEach { (_, probe) -> probe.finish() }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -267,6 +267,16 @@ class DeviceManager {
         service.exportLogsForDevice(serialNumber)
 
     /**
+     * Retrieves the number of records downloaded  from the probe and available in the
+     * log buffer.
+     *
+     * @param serialNumber the serial number of the probe.
+     * @return Count of downloaded records
+     */
+    fun recordsDownloads(serialNumber: String): Int =
+        service.recordsDownloaded(serialNumber)
+
+    /**
      * Retrieves the current temperature log as a Kotlin flow of LoggedProbeDataPoint for
      * the specified serial number.  All logs previously transferred are produced to the flow
      * and new log records are produced to the flow as they are retrieved in real-time from

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
@@ -35,6 +35,7 @@ package inc.combustion.framework.service
  * @property fwVersion Firmware Version
  * @property hwRevision Hardware Revision
  * @property temperatures Current temperature values
+ * @property instantRead Current instant read value
  * @property rssi Received signal strength
  * @property minSequence Minimum log sequence number
  * @property maxSequence Current sequence number
@@ -56,7 +57,8 @@ data class Probe(
     val mac: String,
     val fwVersion: String?,
     val hwRevision: String?,
-    val temperatures: ProbeTemperatures,
+    val temperatures: ProbeTemperatures?,
+    val instantRead: Double?,
     val rssi: Int,
     val minSequence: UInt,
     val maxSequence: UInt,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeColor.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeColor.kt
@@ -1,6 +1,6 @@
 /*
  * Project: Combustion Inc. Android Framework
- * File: Probe.kt
+ * File: ProbeColor.kt
  * Author: https://github.com/miwright2
  *
  * MIT License
@@ -27,42 +27,36 @@
  */
 package inc.combustion.framework.service
 
-/**
- * Data class for the current state of a probe.
- *
- * @property serialNumber Serial Number
- * @property mac Bluetooth MAC Address
- * @property fwVersion Firmware Version
- * @property hwRevision Hardware Revision
- * @property temperatures Current temperature values
- * @property rssi Received signal strength
- * @property minSequence Minimum log sequence number
- * @property maxSequence Current sequence number
- * @property connectionState Connection state
- * @property uploadState Upload State
- * @property id Probe ID
- * @property color Probe Color
- * @property mode Probe Mode
- *
- * @see DeviceConnectionState
- * @see ProbeUploadState
- * @see ProbeTemperatures
- * @see ProbeID
- * @see ProbeColor
- * @see ProbeMode
- */
-data class Probe(
-    val serialNumber: String,
-    val mac: String,
-    val fwVersion: String?,
-    val hwRevision: String?,
-    val temperatures: ProbeTemperatures,
-    val rssi: Int,
-    val minSequence: UInt,
-    val maxSequence: UInt,
-    val connectionState: DeviceConnectionState,
-    val uploadState: ProbeUploadState,
-    val id: ProbeID,
-    val color: ProbeColor,
-    val mode: ProbeMode
-)
+import inc.combustion.framework.ble.shl
+import inc.combustion.framework.ble.shr
+
+enum class ProbeColor(val type: UByte) {
+    COLOR1(0x00u),
+    COLOR2(0x01u),
+    COLOR3(0x02u),
+    COLOR4(0x03u),
+    COLOR5(0x04u),
+    COLOR6(0x05u),
+    COLOR7(0x06u),
+    COLOR8(0x07u);
+
+    companion object {
+        private const val PROBE_COLOR_MASK = 0x07
+        private const val PROBE_COLOR_SHIFT = 2
+
+        fun fromUByte(byte: UByte) : ProbeColor {
+            val rawProbeColor = ((byte.toUShort() and (PROBE_COLOR_MASK.toUShort() shl PROBE_COLOR_SHIFT)) shr PROBE_COLOR_SHIFT).toUInt()
+            return when(rawProbeColor) {
+                0x00u -> COLOR1
+                0x01u -> COLOR2
+                0x02u -> COLOR3
+                0x03u -> COLOR4
+                0x04u -> COLOR5
+                0x05u -> COLOR6
+                0x06u -> COLOR7
+                0x07u -> COLOR8
+                else -> COLOR1
+            }
+        }
+    }
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeID.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeID.kt
@@ -1,6 +1,6 @@
 /*
  * Project: Combustion Inc. Android Framework
- * File: Probe.kt
+ * File: ProbeID.kt
  * Author: https://github.com/miwright2
  *
  * MIT License
@@ -27,42 +27,36 @@
  */
 package inc.combustion.framework.service
 
-/**
- * Data class for the current state of a probe.
- *
- * @property serialNumber Serial Number
- * @property mac Bluetooth MAC Address
- * @property fwVersion Firmware Version
- * @property hwRevision Hardware Revision
- * @property temperatures Current temperature values
- * @property rssi Received signal strength
- * @property minSequence Minimum log sequence number
- * @property maxSequence Current sequence number
- * @property connectionState Connection state
- * @property uploadState Upload State
- * @property id Probe ID
- * @property color Probe Color
- * @property mode Probe Mode
- *
- * @see DeviceConnectionState
- * @see ProbeUploadState
- * @see ProbeTemperatures
- * @see ProbeID
- * @see ProbeColor
- * @see ProbeMode
- */
-data class Probe(
-    val serialNumber: String,
-    val mac: String,
-    val fwVersion: String?,
-    val hwRevision: String?,
-    val temperatures: ProbeTemperatures,
-    val rssi: Int,
-    val minSequence: UInt,
-    val maxSequence: UInt,
-    val connectionState: DeviceConnectionState,
-    val uploadState: ProbeUploadState,
-    val id: ProbeID,
-    val color: ProbeColor,
-    val mode: ProbeMode
-)
+import inc.combustion.framework.ble.shl
+import inc.combustion.framework.ble.shr
+
+enum class ProbeID(val type: UByte) {
+    ID1(0x00u),
+    ID2(0x01u),
+    ID3(0x02u),
+    ID4(0x03u),
+    ID5(0x04u),
+    ID6(0x05u),
+    ID7(0x06u),
+    ID8(0x07u);
+
+    companion object {
+        private const val PROBE_ID_MASK = 0x07
+        private const val PROBE_ID_SHIFT = 5
+
+        fun fromUByte(byte: UByte) : ProbeID {
+            val probeID = ((byte.toUShort() and (PROBE_ID_MASK.toUShort() shl PROBE_ID_SHIFT)) shr PROBE_ID_SHIFT).toUInt()
+            return when(probeID) {
+                0x00u -> ID1
+                0x01u -> ID2
+                0x02u -> ID3
+                0x03u -> ID4
+                0x04u -> ID5
+                0x05u -> ID6
+                0x06u -> ID7
+                0x07u -> ID8
+                else -> ID1
+            }
+        }
+    }
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeMode.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeMode.kt
@@ -1,6 +1,6 @@
 /*
  * Project: Combustion Inc. Android Framework
- * File: Probe.kt
+ * File: ProbeMode.kt
  * Author: https://github.com/miwright2
  *
  * MIT License
@@ -27,42 +27,24 @@
  */
 package inc.combustion.framework.service
 
-/**
- * Data class for the current state of a probe.
- *
- * @property serialNumber Serial Number
- * @property mac Bluetooth MAC Address
- * @property fwVersion Firmware Version
- * @property hwRevision Hardware Revision
- * @property temperatures Current temperature values
- * @property rssi Received signal strength
- * @property minSequence Minimum log sequence number
- * @property maxSequence Current sequence number
- * @property connectionState Connection state
- * @property uploadState Upload State
- * @property id Probe ID
- * @property color Probe Color
- * @property mode Probe Mode
- *
- * @see DeviceConnectionState
- * @see ProbeUploadState
- * @see ProbeTemperatures
- * @see ProbeID
- * @see ProbeColor
- * @see ProbeMode
- */
-data class Probe(
-    val serialNumber: String,
-    val mac: String,
-    val fwVersion: String?,
-    val hwRevision: String?,
-    val temperatures: ProbeTemperatures,
-    val rssi: Int,
-    val minSequence: UInt,
-    val maxSequence: UInt,
-    val connectionState: DeviceConnectionState,
-    val uploadState: ProbeUploadState,
-    val id: ProbeID,
-    val color: ProbeColor,
-    val mode: ProbeMode
-)
+enum class ProbeMode(val type: UByte) {
+    Normal(0x00u),
+    InstantRead(0x01u),
+    Reserved(0x02u),
+    Error(0x03u);
+
+    companion object {
+        private const val PROBE_ID_MASK = 0x03
+
+        fun fromUByte(byte: UByte) : ProbeMode {
+            val probeMode = (byte.toUShort() and PROBE_ID_MASK.toUShort()).toUInt()
+            return when(probeMode) {
+                0x00u -> Normal
+                0x01u -> InstantRead
+                0x02u -> Reserved
+                0x03u -> Error
+                else -> Normal
+            }
+        }
+    }
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeTemperatures.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeTemperatures.kt
@@ -27,10 +27,9 @@
  */
 package inc.combustion.framework.service
 
+import inc.combustion.framework.ble.shl
+import inc.combustion.framework.ble.shr
 import kotlin.random.Random
-
-infix fun UShort.shl(shift: Int) = ((this.toInt() shl shift) and (0x0000FFFF)).toUShort()
-infix fun UShort.shr(shift: Int) = ((this.toInt() shr shift) and (0x0000FFFF)).toUShort()
 
 /**
  * Data class for probe temperature reading.


### PR DESCRIPTION
- Support Instant Read Mode Device Status and Advertising Packets.
- Read Probe ID and Probe Color.  UART commands to set ID and color are pending.
- Filter out timers when publishing Combustion Devices to the Discovered Probes Flow.
- Fixes for CMB-APPS-60 and CMB-APPS-58.

Please use `feature/instant_read_modecolor_timer` branch in `combustion-android` when testing.