### PR TITLE
Foreground Service & ProbeScanner

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,7 +14,6 @@
             <option value="$PROJECT_DIR$/combustion-android-ble" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ A straightforward example Android app illustrating the use of this framework is 
 
 ## The API
 
-The public API and data access objects are contained in the [inc.combustion.framework.service](combustion-android-ble/src/main/java/inc/combustion/framework/service) package.  The [`DeviceManager`](combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt) class is the primary entrypoint for the API.  See the [`DeviceManager`](combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt) source documentation for more details on the API.
+The public API and data access objects are contained in the [inc.combustion.framework.service](combustion-android-ble/src/main/java/inc/combustion/framework/service) package.  The [`DeviceManager`](combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt) class is the primary entrypoint for the API and encapsulates the [Combustion Service](https://github.com/combustion-inc/combustion-android-ble/blob/develop/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt).  See the [`DeviceManager`](combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt) source documentation for more details on the API.
+
+The [`CombustionService`](https://github.com/combustion-inc/combustion-android-ble/blob/develop/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt) manages the communications and data buffer with Combustion devices.  The service can optionally be run in the Foreground, ensuring that it is long-lived, by passing a foreground notification when starting the service.  If your use-case is lighter weight and only needs to access BLE advertisements from the probe, then you can use the [`ProbeScanner`](https://github.com/combustion-inc/combustion-android-ble/blob/develop/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeScanner.kt) and [`ProbeScanResult`](https://github.com/combustion-inc/combustion-android-ble/blob/develop/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeScanResult.kt).
+
+The [Android example](https://github.com/combustion-inc/combustion-android-example) provides more detail on using these APIs.
 
 ## Adding the Library to Your Project
 You can find our library on [JitPack](https://jitpack.io/#combustion-inc/combustion-android-ble).  Go to that page for instructions on setting up your root `build.gradle` to use the JitPack repository and add the library dependency to your build.  See our [`build.gradle`](combustion-android-ble/build.gradle) for the compiler arguments and dependencies used by the library.
@@ -54,7 +58,4 @@ Your feedback is important.  For requesting new features or reporting issues use
 
 The following features are planned for near-term development:
 
-- **Set ring color**: Methods for setting a probe's identifying silicone ring color  (colors TBA).
-- **Set numeric ID**: Methods for setting a probe's numeric ID (1-8).
 - **Firmware update**: Methods for updating a Probe's firmware with a signed firmware image.
-- **Instant Read**: Receiving Instant Read temperature updates in real-time from the probe.

--- a/combustion-android-ble/build.gradle
+++ b/combustion-android-ble/build.gradle
@@ -39,6 +39,19 @@ android {
         }
     }
 
+    // see: https://developer.android.com/studio/write/lint
+    lint {
+        // If set to true, turns off analysis progress reporting by lint.
+        quiet true
+        // If set to true (default), stops the build if errors are found.
+        abortOnError true
+        // If true, only report errors.
+        ignoreWarnings false
+        // If true, lint also checks all dependencies as part of its analysis. Recommended for
+        // projects consisting of an app with library dependencies.
+        checkDependencies true
+    }
+
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
             freeCompilerArgs += [

--- a/combustion-android-ble/src/main/AndroidManifest.xml
+++ b/combustion-android-ble/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
                      android:usesPermissionFlags="neverForLocation"

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeAdvertisingData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeAdvertisingData.kt
@@ -129,7 +129,6 @@ internal data class ProbeAdvertisingData (
                     probeMode
                 )
             }
-
         }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
@@ -105,7 +105,7 @@ class CombustionService : LifecycleService() {
         var serviceNotification : Notification? = null
         var notificationId = 0
 
-        fun start(context: Context, notification: Notification): Int {
+        fun start(context: Context, notification: Notification?): Int {
             Log.d(LOG_TAG, "Starting Combustion Android Service ...")
             serviceNotification = notification
             notificationId = ThreadLocalRandom.current().asKotlinRandom().nextInt()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -93,10 +93,11 @@ class DeviceManager {
         /**
          * Starts the Combustion Android Service as a Foreground Service
          *
-         * @param notification Foreground notification for the service
+         * @param notification Optional notification for the service.  If provided the service is run
+         *  in the foreground.
          * @return notification ID
          */
-        fun startCombustionService(notification: Notification): Int {
+        fun startCombustionService(notification: Notification?): Int {
             return CombustionService.start(app.applicationContext, notification)
         }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -28,6 +28,7 @@
 package inc.combustion.framework.service
 
 import android.app.Application
+import android.app.Notification
 import android.content.ComponentName
 import android.content.ServiceConnection
 import android.os.IBinder
@@ -90,10 +91,13 @@ class DeviceManager {
         }
 
         /**
-         * Starts the Combustion Android Service
+         * Starts the Combustion Android Service as a Foreground Service
+         *
+         * @param notification Foreground notification for the service
+         * @return notification ID
          */
-        fun startCombustionService() {
-            CombustionService.start(app.applicationContext)
+        fun startCombustionService(notification: Notification): Int {
+            return CombustionService.start(app.applicationContext, notification)
         }
 
         /**

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeScanResult.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeScanResult.kt
@@ -1,0 +1,75 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: ProbeScanResult.kt
+ * Author: https://github.com/miwright2
+ *
+ * MIT License
+ *
+ * Copyright (c) 2022. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package inc.combustion.framework.service
+
+import com.juul.kable.Advertisement
+import inc.combustion.framework.ble.ProbeAdvertisingData
+
+/**
+ * Data class for returning BLE scan results.
+ *
+ * @property serialNumber serial number of probe
+ * @property temperatures normal temperature reading of probe
+ * @property instantReadTemperature instant read temperature reading of probe
+ */
+data class ProbeScanResult(
+    val serialNumber: String?,
+    val temperatures: ProbeTemperatures?,
+    val instantReadTemperature: Double?
+){
+    companion object {
+        fun fromAdvertisement(advertisement: Advertisement) : ProbeScanResult? {
+            val data = ProbeAdvertisingData.fromAdvertisement(advertisement)
+
+            data?.let {
+                if(it.type != ProbeAdvertisingData.CombustionProductType.PROBE)
+                    return null
+
+                val serialNumber = it.serialNumber
+
+                val temperatures = if (it.mode == ProbeMode.Normal)
+                    it.probeTemperatures
+                else
+                    null
+
+                val instantReadTemperature = if (it.mode == ProbeMode.InstantRead)
+                    it.probeTemperatures.values[0]
+                else
+                    null
+
+                return ProbeScanResult(
+                    serialNumber,
+                    temperatures ,
+                    instantReadTemperature
+                )
+            }
+
+            return null
+        }
+    }
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeScanner.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeScanner.kt
@@ -1,0 +1,100 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: ProbeScanner.kt
+ * Author: https://github.com/miwright2
+ *
+ * MIT License
+ *
+ * Copyright (c) 2022. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package inc.combustion.framework.service
+
+import android.bluetooth.le.ScanSettings
+import android.util.Log
+import androidx.lifecycle.*
+import com.juul.kable.Scanner
+import inc.combustion.framework.LOG_TAG
+import inc.combustion.framework.ble.ProbeManager
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Scans for Combustion Probes outside of the Combustion Service.  Caller is responsible for
+ * ensuring the Bluetooth is enabled prior to starting the scanner.  This class returns scan
+ * results from the provided flow, only for Combustion probes.  This class returns a new
+ * scan result for each advertisement received from a probe.
+ */
+class ProbeScanner private constructor() {
+
+    companion object {
+        private var job: Job? = null
+        private val scanning = AtomicBoolean(false)
+        private val _results = MutableSharedFlow<ProbeScanResult>()
+
+        val scanResults = _results.asSharedFlow()
+
+        private val probeAllMatchesScanner = Scanner {
+            services = listOf(ProbeManager.NEEDLE_SERVICE_UUID.uuid)
+            scanSettings = ScanSettings.Builder()
+                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                .setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE)
+                .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+                .build()
+        }
+
+        val isScanning: Boolean
+            get() = scanning.get()
+
+        fun start(owner: LifecycleOwner) {
+            if(!scanning.getAndSet(true)) {
+                job = owner.lifecycleScope.launch {
+                    owner.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                        probeAllMatchesScanner
+                            .advertisements
+                            .catch { cause ->
+                                stop()
+                                scanning.set(false)
+                                Log.e(LOG_TAG, "ProbeScanner Error: ${cause.localizedMessage}")
+                                Log.e(LOG_TAG, Log.getStackTraceString(cause))
+                            }
+                            .onCompletion {
+                                Log.d(LOG_TAG, "ProbeScanner Complete...")
+                                scanning.set(false)
+                            }
+                            .collect { advertisement ->
+                                ProbeScanResult.fromAdvertisement(advertisement).let {
+                                    it?.let {
+                                        _results.emit(it)
+                                    }
+                                }
+                            }
+                    }
+                }
+            }
+        }
+
+        fun stop() {
+            job?.cancelChildren()
+            job = null
+        }
+    }
+}


### PR DESCRIPTION
- Ability to optionally launch and run the Combustion Service as a foreground service.
- Calling app is responsible for creating the `Notification` and passing that into the service on start.
- Passing in null for the `Notification` results in the service being run in the background.
- Add `ProbeScanner` and `ProbeScanResult` to the public framework API to allow calling apps to scan for and identify Combustion probes independent of the Combustion Service.

Please test with `feature/foreground-service_and_scanning` in `combustion-android` repo.  Related PR is [here](https://github.com/combustion-inc/combustion-android/pull/26)  Example app updates are pending.