### PR TITLE
Service Lifecycle

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -145,6 +145,10 @@ internal class LogManager {
                                         )
                                     }
 
+                                    // only log normal mode packets
+                                    if(deviceStatus.mode != ProbeMode.Normal)
+                                        return@collect
+
                                     // add the device status to the temperature log
                                     val sessionStatus = temperatureLog.addFromDeviceStatus(deviceStatus)
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
@@ -123,7 +123,7 @@ class CombustionService : LifecycleService() {
 
         fun bind(context: Context, connection: ServiceConnection) {
             Intent(context, CombustionService::class.java).also { intent ->
-                val flags = Context.BIND_AUTO_CREATE or Context.BIND_IMPORTANT or Context.BIND_ABOVE_CLIENT
+                val flags = Context.BIND_AUTO_CREATE
                 context.bindService(intent, connection, flags)
             }
         }
@@ -214,6 +214,7 @@ class CombustionService : LifecycleService() {
         }
 
         startForeground()
+
         serviceIsStarted.set(true)
 
         Log.d(LOG_TAG, "Combustion Android Service Started...")

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 import kotlin.random.asKotlinRandom
 
@@ -171,6 +172,21 @@ class CombustionService : LifecycleService() {
         }
     }
 
+    private fun startForeground() {
+        serviceNotification?.let {
+            startForeground(notificationId, serviceNotification)
+        }
+    }
+
+    private fun stopForeground() {
+        serviceNotification?.let {
+            val service = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            service.cancel(notificationId)
+
+            stopForeground(true)
+        }
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
 
@@ -197,10 +213,7 @@ class CombustionService : LifecycleService() {
             emitBluetoothOffEvent()
         }
 
-        serviceNotification?.let {
-            startForeground(notificationId, serviceNotification)
-        }
-
+        startForeground()
         serviceIsStarted.set(true)
 
         Log.d(LOG_TAG, "Combustion Android Service Started...")
@@ -210,22 +223,18 @@ class CombustionService : LifecycleService() {
 
     override fun onBind(intent: Intent): IBinder {
         super.onBind(intent)
-        Log.d(LOG_TAG, "Combustion Android Service Bound...")
         return binder
     }
 
     override fun onUnbind(intent: Intent?): Boolean {
-        Log.d(LOG_TAG, "Combustion Android Service Unbound...")
+        stopForeground()
         return super.onUnbind(intent)
     }
 
     override fun onDestroy() {
         // stop the service notification
+        stopForeground()
         serviceNotification = null
-        val service = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        service.cancel(notificationId)
-
-        stopForeground(true)
 
         // always try to unregister, even if the previous register didn't complete.
         try { unregisterReceiver(_bluetoothReceiver) } catch (e: Exception) { }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DebugSettings.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DebugSettings.kt
@@ -35,5 +35,6 @@ class DebugSettings {
         var DEBUG_LOG_BLE_UART_IO = false
         var DEBUG_LOG_CONNECTION_STATE = false
         var DEBUG_LOG_BLE_OPERATIONS = false
+        var DEBUG_LOG_SERVICE_LIFECYCLE = false
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -37,6 +37,7 @@ import inc.combustion.framework.LOG_TAG
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Singleton instance for managing communications with Combustion Inc. devices.
@@ -50,7 +51,8 @@ class DeviceManager {
         private lateinit var app : Application
         private lateinit var onServiceBound : (deviceManager: DeviceManager) -> Unit
         private val initialized = AtomicBoolean(false)
-        private val bound = AtomicBoolean(false)
+        private val connected = AtomicBoolean(false)
+        private val bindingCount = AtomicInteger(0)
 
         private val connection = object : ServiceConnection {
 
@@ -58,7 +60,7 @@ class DeviceManager {
                 val binder = serviceBinder as CombustionService.CombustionServiceBinder
                 INSTANCE.service = binder.getService()
 
-                bound.set(true)
+                connected.set(true)
                 onServiceBound(INSTANCE)
 
                 INSTANCE.onBoundInitList.forEach{ initCallback ->
@@ -67,8 +69,7 @@ class DeviceManager {
             }
 
             override fun onServiceDisconnected(arg0: ComponentName) {
-                bound.set(false)
-                bindCombustionService()
+                connected.set(false)
             }
         }
 
@@ -80,7 +81,7 @@ class DeviceManager {
         /**
          * Initializes the singleton
          * @param application Application context.
-         * @param onBound Lambda to be called when the service is bound to an Activity.
+         * @param onBound Lambda to be called when the service is connected to an Activity.
          */
         fun initialize(application: Application, onBound: (deviceManager: DeviceManager) -> Unit) {
             if(!initialized.getAndSet(true)) {
@@ -98,6 +99,8 @@ class DeviceManager {
          * @return notification ID
          */
         fun startCombustionService(notification: Notification?): Int {
+            if(DebugSettings.DEBUG_LOG_SERVICE_LIFECYCLE)
+                Log.d(LOG_TAG, "Start Service")
             return CombustionService.start(app.applicationContext, notification)
         }
 
@@ -105,23 +108,43 @@ class DeviceManager {
          * Binds to the Combustion Android Service
          */
         fun bindCombustionService() {
-            if(!bound.get()) {
+            val count = bindingCount.getAndIncrement()
+            if(!connected.get() && count == 0) {
+                if(DebugSettings.DEBUG_LOG_SERVICE_LIFECYCLE)
+                    Log.d(LOG_TAG, "Binding Service")
+
                 CombustionService.bind(app.applicationContext, connection)
             }
+
+            if(DebugSettings.DEBUG_LOG_SERVICE_LIFECYCLE)
+                Log.d(LOG_TAG, "Binding Reference Count (${count + 1})")
         }
 
         /**
          * Unbinds from the Combustion Android Service
          */
         fun unbindCombustionService() {
-            app.unbindService(connection)
-            bound.set(false)
+            val count = bindingCount.decrementAndGet()
+            if(connected.get() && count <= 0) {
+                if(DebugSettings.DEBUG_LOG_SERVICE_LIFECYCLE)
+                    Log.d(LOG_TAG, "Unbinding Service")
+
+                app.unbindService(connection)
+            }
+
+            if(DebugSettings.DEBUG_LOG_SERVICE_LIFECYCLE)
+                Log.d(LOG_TAG, "Binding Reference Count ($count)")
         }
 
         /**
-         * Stops the Combustion Android Sevice
+         * Stops the Combustion Android Service
          */
         fun stopCombustionService() {
+            if(DebugSettings.DEBUG_LOG_SERVICE_LIFECYCLE)
+                Log.d(LOG_TAG, "Unbinding & Binding Service")
+
+            bindingCount.set(0)
+            app.unbindService(connection)
             CombustionService.stop(app.applicationContext)
         }
     }
@@ -155,8 +178,8 @@ class DeviceManager {
      * @param callback Lambda to be called by the Device Manager upon completing initialization.
      */
     fun registerOnBoundInitialization(callback : () -> Unit) {
-        // if service is already bound, then run the callback right away.
-        if(bound.get()) {
+        // if service is already connected, then run the callback right away.
+        if(connected.get()) {
             callback()
         }
         // otherwise queue the callback to be run when the service is bound.


### PR DESCRIPTION
- Incorporate reference counting in the DeviceManager to better handle the lifecycle management APIs across multiple activities.
- README.md in the example project explains the lifecycle management guidelines.

Please test with `combustion-android-ble` branch `feature/service_lifecycle`