### PR TITLE
Add CRC Calculation and Checking to UART Messages

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/Extensions.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/Extensions.kt
@@ -28,7 +28,54 @@
 package inc.combustion.framework.ble
 
 /**
- * Convert to UInt16 at the specified index.
+ * Calculates the 16 bit * Cyclic Redundancy Check (CRC-CCIIT 0xFFFF) with an initial value of
+ * 0xFFFF and the polynomial 0x1021.
+ *
+ * 1 + x + x^5 + x^12 + x^16 is irreducible polynomial.
+ *
+ * Adapted from: https://introcs.cs.princeton.edu/java/61data/CRC16CCITT.java
+ */
+internal fun UByteArray.getCRC16CCITT() : UShort {
+    var crc: UShort = 0xFFFFu // initial value
+    val polynomial: UShort = 0x1021u // 0001 0000 0010 0001  (0, 5, 12)
+
+    for (b in this) {
+        for (i in 0..7) {
+            val bit = (b   shr (7 - i) and 1u) == 1u.toUShort()
+            val c15 = (crc shr (15)    and 1u) == 1u.toUShort()
+            crc = crc shl 1
+            if (c15 xor bit) crc = crc xor polynomial
+        }
+    }
+
+    return crc and 0xFFFFu
+}
+
+
+/**
+ * Convert to UShort at the specified index.
+ *
+ * @param index index into buffer
+ * @return UShort at index.
+ */
+internal fun UByteArray.getLittleEndianUShortAt(index: Int) : UShort {
+    return ((this[index+1].toUShort() and 0xFFu) shl 8) or
+            (this[index].toUShort() and 0xFFu)
+}
+
+/**
+ * Stores a UShort at the specified index.
+ *
+ * @param index index into buffer
+ * @param value value to put into buffer at index.
+ */
+internal fun UByteArray.putLittleEndianUShortAt(index: Int, value: UShort) {
+    this[index] = (value and 0x00FFu).toUByte()
+    this[index + 1] = ((value and 0xFF00u) shr 8).toUByte()
+}
+
+/**
+ * Convert to UInt at the specified index.
  *
  * @param index index into buffer
  * @return UInt at index.
@@ -64,6 +111,9 @@ internal fun UByteArray.putLittleEndianUInt32At(index: Int, value: UInt) {
     this[index + 2] = ((value and 0x00FF0000u) shr 16).toUByte()
     this[index + 3] = ((value and 0xFF000000u) shr 24).toUByte()
 }
+
+infix fun UByte.shl(shift: Int) = ((this.toInt() shl shift) and (0x0000FFFF)).toUShort()
+infix fun UByte.shr(shift: Int) = ((this.toInt() shr shift) and (0x0000FFFF)).toUShort()
 
 infix fun UShort.shl(shift: Int) = ((this.toInt() shl shift) and (0x0000FFFF)).toUShort()
 infix fun UShort.shr(shift: Int) = ((this.toInt() shr shift) and (0x0000FFFF)).toUShort()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/LogRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/LogRequest.kt
@@ -51,5 +51,7 @@ internal class LogRequest(
     init {
         data.putLittleEndianUInt32At((HEADER_SIZE + 0u).toInt(), minSequence)
         data.putLittleEndianUInt32At((HEADER_SIZE + 4u).toInt(), maxSequence)
+
+        setCRC()
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/Request.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/Request.kt
@@ -69,7 +69,6 @@ internal open class Request(
      * result in the correct location in the packet.
      */
     fun setCRC() {
-        // TODO: Uncomment this when it's time to add the CRC to outgoing messages
-        // data.putLittleEndianUShortAt(2, data.drop(4).toUByteArray().getCRC16CCITT())
+        data.putLittleEndianUShortAt(2, data.drop(4).toUByteArray().getCRC16CCITT())
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/Request.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/Request.kt
@@ -27,6 +27,9 @@
  */
 package inc.combustion.framework.ble.uart
 
+import inc.combustion.framework.ble.getCRC16CCITT
+import inc.combustion.framework.ble.putLittleEndianUShortAt
+
 /**
  * Baseclass for UART request messages
  *
@@ -52,10 +55,21 @@ internal open class Request(
         data[0] = 0xCAu
         data[1] = 0xFEu
 
+        // CRC needs to be set after the payload's been added
+
         // Message type
         data[4] = type.value
 
         // Payload length
         data[5] = payloadLength
+    }
+
+    /**
+     * Calculates the CRC16 over the message type, payload length, and payload and inserts the
+     * result in the correct location in the packet.
+     */
+    fun setCRC() {
+        // TODO: Uncomment this when it's time to add the CRC to outgoing messages
+        // data.putLittleEndianUShortAt(2, data.drop(4).toUByteArray().getCRC16CCITT())
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/Response.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/Response.kt
@@ -114,14 +114,13 @@ internal open class Response(
             val calculatedCrc: UShort = data.drop(4).slice(0 until length.toInt() + 3).toUByteArray().getCRC16CCITT()
             val sentCrc: UShort = data.getLittleEndianUShortAt(2)
 
-            // TODO: Return bad packet when CRC is ill-formed
             if (sentCrc != calculatedCrc) {
-                // Log.w(
-                //     "$LOG_TAG.Response",
-                //     "Incorrect CRC (got: $sentCrc; expected: $calculatedCrc) (total: ${stats.invalidCrc.incrementAndGet()})"
-                // )
+                Log.w(
+                     "$LOG_TAG.Response",
+                     "Incorrect CRC (got: $sentCrc; expected: $calculatedCrc) (total: ${stats.invalidCrc.incrementAndGet()})"
+                )
 
-                // return null
+                return null
             }
 
             // validate payload length and construct response

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SessionInfoRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SessionInfoRequest.kt
@@ -34,4 +34,8 @@ internal class SessionInfoRequest(
     companion object {
         const val PAYLOAD_LENGTH: UByte = 0u
     }
+
+    init {
+        setCRC()
+    }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SetColorRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SetColorRequest.kt
@@ -40,6 +40,8 @@ internal class SetColorRequest(
 
     init {
         data[(HEADER_SIZE).toInt()] = color.type
+
+        setCRC()
     }
 }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SetIDRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SetIDRequest.kt
@@ -40,5 +40,7 @@ internal class SetIDRequest(
 
     init {
         data[(HEADER_SIZE).toInt()] = id.type
+
+        setCRC()
     }
 }


### PR DESCRIPTION
- Check CRC on response messages.
- Calculate and send CRC on request messages.
- Firmware greater than v0.8.2 requires this feature.

Tested data transfer, set probe id, and probe color. 