### PR TITLE
Set Prediction

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -97,6 +97,7 @@ internal open class ProbeManager (
     }
 
     private var probeStatus: ProbeStatus? = null
+    private var predictionStatus: PredictionStatus? = null
     private var connectionState = DeviceConnectionState.OUT_OF_RANGE
     private var uploadState: ProbeUploadState = ProbeUploadState.Unavailable
 
@@ -303,6 +304,7 @@ internal open class ProbeManager (
             monitor.activity()
             advertisingData = newAdvertisingData
             probeStatus = null
+            predictionStatus = null
             _probeStateFlow.emit(probe)
         }
     }
@@ -349,6 +351,7 @@ internal open class ProbeManager (
             else {
                 probeStatus = null
                 sessionInfo = null
+                predictionStatus = null
             }
 
             if(DebugSettings.DEBUG_LOG_CONNECTION_STATE) {
@@ -495,19 +498,13 @@ internal open class ProbeManager (
         val mode = probeStatus?.mode ?: advertisingData.mode
         val batteryStatus = probeStatus?.batteryStatus ?: advertisingData.batteryStatus
         val virtualSensors = probeStatus?.virtualSensors ?: advertisingData.virtualSensors
-        val predictionState = probeStatus?.predictionStatus?.predictionState
-        val predictionMode = probeStatus?.predictionStatus?.predictionMode
-        val predictionType = probeStatus?.predictionStatus?.predictionType
-        val setPointTemperatureC = probeStatus?.predictionStatus?.setPointTemperature
-        val heatStartTemperatureC = probeStatus?.predictionStatus?.heatStartTemperature
-        val predictionS = probeStatus?.predictionStatus?.predictionValueSeconds
-        val estimatedCoreC = probeStatus?.predictionStatus?.estimatedCoreTemperature
 
         if(mode == ProbeMode.INSTANT_READ) {
             instantReadMonitor.activity()
             instantRead = temps.values[0]
         } else {
             temperatures = temps
+            predictionStatus = probeStatus?.predictionStatus
 
             coreTemperature = when(virtualSensors.virtualCoreSensor) {
                 ProbeVirtualSensors.VirtualCoreSensor.T1 -> temps.values[0]
@@ -536,6 +533,14 @@ internal open class ProbeManager (
                 instantRead = null
             }
         }
+
+        val predictionState = predictionStatus?.predictionState
+        val predictionMode = predictionStatus?.predictionMode
+        val predictionType = predictionStatus?.predictionType
+        val setPointTemperatureC = predictionStatus?.setPointTemperature
+        val heatStartTemperatureC = predictionStatus?.heatStartTemperature
+        val predictionS = predictionStatus?.predictionValueSeconds
+        val estimatedCoreC = predictionStatus?.estimatedCoreTemperature
 
         return Probe(
             advertisingData.serialNumber,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
@@ -334,11 +334,27 @@ class CombustionService : LifecycleService() {
     }
 
     internal fun setProbeColor(serialNumber: String, color: ProbeColor, completionHandler: (Boolean) -> Unit) {
-        _probes[serialNumber]?.sendSetProbeColor(this, color, completionHandler)
+        _probes[serialNumber]?.sendSetProbeColor(this, color, completionHandler) ?: run {
+            completionHandler(false)
+        }
     }
 
     internal fun setProbeID(serialNumber: String, id: ProbeID, completionHandler: (Boolean) -> Unit) {
-        _probes[serialNumber]?.sendSetProbeID(this, id, completionHandler)
+        _probes[serialNumber]?.sendSetProbeID(this, id, completionHandler) ?: run {
+            completionHandler(false)
+        }
+    }
+
+    internal fun setRemovalPrediction(serialNumber: String, removalTemperatureC: Double, completionHandler: (Boolean) -> Unit) {
+        _probes[serialNumber]?.sendSetPrediction(this, removalTemperatureC, ProbePredictionMode.TIME_TO_REMOVAL, completionHandler) ?: run {
+            completionHandler(false)
+        }
+    }
+
+    internal fun cancelPrediction(serialNumber: String, completionHandler: (Boolean) -> Unit) {
+        _probes[serialNumber]?.sendSetPrediction(this, DeviceManager.MINIMUM_PREDICTION_SETPOINT_CELSIUS, ProbePredictionMode.NONE, completionHandler) ?: run {
+            completionHandler(false)
+        }
     }
 
     private fun emitBluetoothOnEvent() = _discoveredProbesFlow.tryEmit(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -78,6 +78,9 @@ class DeviceManager {
             }
         }
 
+        const val MINIMUM_PREDICTION_SETPOINT_CELSIUS = 0.0
+        const val MAXIMUM_PREDICTION_SETPOINT_CELSIUS = 102.0
+
         /**
          * Instance property for the singleton
          */
@@ -391,6 +394,33 @@ class DeviceManager {
      */
     fun setProbeID(serialNumber: String, id: ProbeID, completionHandler: (Boolean) -> Unit) =
         service.setProbeID(serialNumber, id, completionHandler)
+
+    /**
+     * Sends a request to the device to set/change the set point temperature for the time to
+     * removal prediction.  If a prediction is not currently active, it will be started.  If a
+     * removal prediction is currently active, then the set point will be modified.  If another
+     * type of prediction is active, then the probe will start predicting removal.
+     *
+     * @param serialNumber the serial number of the probe.
+     * @param removalTemperatureC the target removal temperature in Celsius.
+     * @param completionHandler completion handler to be called operation is complete
+     */
+    fun setRemovalPrediction(serialNumber: String, removalTemperatureC: Double, completionHandler: (Boolean) -> Unit) {
+        if(removalTemperatureC > MAXIMUM_PREDICTION_SETPOINT_CELSIUS || removalTemperatureC < MINIMUM_PREDICTION_SETPOINT_CELSIUS) {
+            completionHandler(false)
+            return
+        }
+        service.setRemovalPrediction(serialNumber, removalTemperatureC, completionHandler)
+    }
+
+    /**
+     * Sends a request to the device to set the prediction mode to none, stopping any active prediction.
+     *
+     * @param serialNumber the serial number of the probe.
+     * @param completionHandler completion handler to be called operation is complete
+     */
+    fun cancelPrediction(serialNumber: String, completionHandler: (Boolean) -> Unit) =
+        service.cancelPrediction(serialNumber, completionHandler)
 
     private fun probeDataToCsv(probe: Probe?, probeData: List<LoggedProbeDataPoint>?, appNameAndVersion: String): Pair<String, String> {
         val csvVersion = 3

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbePredictionState.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbePredictionState.kt
@@ -33,7 +33,7 @@ import inc.combustion.framework.ble.shr
 enum class ProbePredictionState(val uByte: UByte) {
     PROBE_NOT_INSERTED(0x00u),
     PROBE_INSERTED(0x01u),
-    WARMING(0x02u),
+    COOKING(0x02u),
     PREDICTING(0x03u),
     REMOVAL_PREDICTION_DONE(0x04u),
     RESERVED_STATE_5(0x05u),
@@ -71,7 +71,7 @@ enum class ProbePredictionState(val uByte: UByte) {
             return when(raw) {
                 0x00u -> PROBE_NOT_INSERTED
                 0x01u -> PROBE_INSERTED
-                0x02u -> WARMING
+                0x02u -> COOKING
                 0x03u -> PREDICTING
                 0x04u -> REMOVAL_PREDICTION_DONE
                 0x05u -> RESERVED_STATE_5


### PR DESCRIPTION
- API for setting and canceling a prediction.
- Change Warming State to Cooking State.

Requires this Probe FW
https://github.com/combustion-inc/meat-dagger-firmware/pull/128

Requires this Android Example App
https://github.com/combustion-inc/combustion-android-example/pull/20