### PR TITLE
DROID-91: MeatNet connection management

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -157,11 +157,12 @@ internal class DataLinkArbitrator(
             // if not using meatnet, and the client app is asking us to connect
             if(fromApiCall) {
                 device.shouldAutoReconnect = settings.autoReconnect
+                return canConnect
             }
 
             // if not using meatnet, and this is a call from inside the framework then
             // we want to use the auto-reconnect setting.
-            return canConnect
+            return device.shouldAutoReconnect
         }
 
         // if not meatnet and not a probe
@@ -196,6 +197,14 @@ internal class DataLinkArbitrator(
     fun shouldUpdateOnOutOfRange(device: ProbeBleDeviceBase): Boolean {
         // TODO: Implement Multiplexing Business Logic
         return debuggingWithStaticLink(device)
+    }
+
+    fun shouldHandleAdvertisingPacket(device: ProbeBleDeviceBase): Boolean {
+        /*
+        return true
+        */
+        return device.connectionState == DeviceConnectionState.ADVERTISING_CONNECTABLE ||
+                device.connectionState == DeviceConnectionState.ADVERTISING_NOT_CONNECTABLE
     }
 
     fun shouldUpdateDataFromAdvertisingPacket(device: ProbeBleDeviceBase): Boolean {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -1,0 +1,228 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: DataLinkArbitrator.kt
+ * Author: https://github.com/miwright2
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.ble
+
+import android.util.Log
+import inc.combustion.framework.ble.device.*
+import inc.combustion.framework.ble.device.ProbeBleDevice
+import inc.combustion.framework.ble.device.ProbeBleDeviceBase
+import inc.combustion.framework.ble.device.RepeatedProbeBleDevice
+import inc.combustion.framework.service.DeviceConnectionState
+import inc.combustion.framework.service.DeviceManager
+
+internal class DataLinkArbitrator(
+    private val settings: DeviceManager.Settings
+) {
+    // direct ble link to probe
+    private var probeBleDevice: ProbeBleDevice? = null
+
+    // meatnet links to probe
+    private val repeatedProbeBleDevices = mutableListOf<RepeatedProbeBleDevice>()
+
+    // metnet network nodes
+    private val networkNodes = hashMapOf<DeviceID, DeviceInformationBleDevice>()
+
+    fun finish() {
+        networkNodes.forEach { it.value.finish() }
+        repeatedProbeBleDevices.clear()
+        networkNodes.clear()
+        probeBleDevice = null
+    }
+
+    fun addProbe(probe: ProbeBleDevice, baseDevice: DeviceInformationBleDevice): Boolean {
+        if(probeBleDevice == null) {
+            probeBleDevice = probe
+            networkNodes[baseDevice.id] = baseDevice
+            return true
+        }
+
+        return false
+    }
+
+    fun addRepeatedProbe(repeatedProbe: RepeatedProbeBleDevice, repeater: DeviceInformationBleDevice): Boolean {
+        repeatedProbeBleDevices.add(repeatedProbe)
+        if(!networkNodes.containsKey(repeater.id)) {
+            networkNodes[repeater.id] = repeater
+        }
+        return true
+    }
+
+    fun handleOutOfRange(device: ProbeBleDeviceBase) {
+        when(device) {
+            is ProbeBleDevice -> {
+                // TODO
+            }
+            is RepeatedProbeBleDevice -> {
+                // TODO
+            }
+        }
+    }
+
+    fun handleConnectionState(device: ProbeBleDeviceBase, state: DeviceConnectionState) {
+        // TODO -- Handle Connection State Changes
+    }
+
+    fun getDevice(id: DeviceID): DeviceInformationBleDevice? {
+        if(networkNodes.containsKey(id)) {
+            return networkNodes[id]
+        }
+        return null
+    }
+
+    fun getNodesNeedingConnection(fromApiCall: Boolean = false): List<DeviceInformationBleDevice> {
+        val connectable = mutableListOf<DeviceID>()
+        // for meatnet links
+        repeatedProbeBleDevices.forEach {
+            // should connect to this repeated probe
+            if(shouldConnect(it, fromApiCall)) {
+                // if don't already plan to connect to the repeater for the repeated probe
+                if(!connectable.contains(it.id)) {
+                    // add to the list of meatnet devices we need to connect to
+                    connectable.add(it.id)
+                }
+            }
+        }
+
+        // should direct connect to the probe
+        probeBleDevice?.let {
+            if(shouldConnect(it, fromApiCall)) {
+                connectable.add(it.id)
+            }
+        }
+
+        return networkNodes.filter {
+            entry: Map.Entry<DeviceID, DeviceInformationBleDevice> -> connectable.contains(entry.key)
+        }.values.toList()
+    }
+
+    fun getNodesNeedingDisconnect(fromApiCall: Boolean = false): List<DeviceInformationBleDevice> {
+        val disconnectable = mutableListOf<DeviceID>()
+        // for meatnet links
+        repeatedProbeBleDevices.forEach {
+            // should disconnect from this repeated probe
+            if(shouldDisconnect(it, fromApiCall)) {
+                // if don't already plan to disconnect from the repeater for the repeated probe
+                if(!disconnectable.contains(it.id)) {
+                    // add to the list of meatnet devices we need to disconnect from
+                    disconnectable.add(it.id)
+                }
+            }
+        }
+
+        // should disconnect form a direct connect to the probe
+        probeBleDevice?.let {
+            if(shouldDisconnect(it, fromApiCall)) {
+                disconnectable.add(it.id)
+            }
+        }
+
+        return networkNodes.filter {
+            entry: Map.Entry<DeviceID, DeviceInformationBleDevice> -> disconnectable.contains(entry.key)
+        }.values.toList()
+    }
+
+    fun shouldConnect(device: ProbeBleDeviceBase, fromApiCall: Boolean = false): Boolean {
+        val canConnect = device.isDisconnected && device.isConnectable
+        if(settings.meatNetEnabled) {
+            // connect to every connectable device when using meatnet
+            return canConnect
+        }
+        else if(device is ProbeBleDevice) {
+            // if not using meatnet, and the client app is asking us to connect
+            if(fromApiCall) {
+                device.shouldAutoReconnect = settings.autoReconnect
+            }
+
+            // if not using meatnet, and this is a call from inside the framework then
+            // we want to use the auto-reconnect setting.
+            return canConnect
+        }
+
+        // if not meatnet and not a probe
+        return false
+    }
+
+    fun shouldDisconnect(device: ProbeBleDeviceBase, fromApiCall: Boolean = false): Boolean {
+        val canDisconnect = device.isConnected
+        if(settings.meatNetEnabled) {
+            // don't disconnect from meatnet
+            return false
+        }
+        else if(device is ProbeBleDevice) {
+            // if not using meatnet, and the client app is asking us to disconnect,
+            // then turn off the auto-reconnect flag
+            if(fromApiCall) {
+                device.shouldAutoReconnect = false
+            }
+
+            // additionally disconnect if we can
+            return canDisconnect
+        }
+
+        // if not meatnet and not a probe
+        return false
+    }
+
+    fun shouldUpdateOnDeviceInfoRead(device: ProbeBleDeviceBase): Boolean {
+        return device is ProbeBleDevice
+    }
+
+    fun shouldUpdateOnOutOfRange(device: ProbeBleDeviceBase): Boolean {
+        // TODO: Implement Multiplexing Business Logic
+        return debuggingWithStaticLink(device)
+    }
+
+    fun shouldUpdateDataFromAdvertisingPacket(device: ProbeBleDeviceBase): Boolean {
+        // TODO: Implement Multiplexing Business Logic
+        return debuggingWithStaticLink(device)
+    }
+
+    fun shouldUpdateConnectionStateFromAdvertisingPacket(device: ProbeBleDeviceBase): Boolean {
+        // TODO: Implement Multiplexing Business Logic
+        return debuggingWithStaticLink(device)
+    }
+
+    fun shouldUpdateOnConnectionState(device: ProbeBleDeviceBase, state: DeviceConnectionState): Boolean {
+        // TODO: Implement Multiplexing Business Logic
+        return debuggingWithStaticLink(device)
+    }
+
+    fun shouldUpdateOnRemoteRssi(device: ProbeBleDeviceBase, rssi: Int): Boolean {
+        // TODO: Implement Multiplexing Business Logic
+        return debuggingWithStaticLink(device)
+    }
+
+    private fun debuggingWithStaticLink(device: ProbeBleDeviceBase): Boolean {
+        return when(device) {
+            is ProbeBleDevice -> true
+            is RepeatedProbeBleDevice -> false
+            else -> false
+        }
+    }
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -200,9 +200,6 @@ internal class DataLinkArbitrator(
     }
 
     fun shouldHandleAdvertisingPacket(device: ProbeBleDeviceBase): Boolean {
-        /*
-        return true
-        */
         return device.connectionState == DeviceConnectionState.ADVERTISING_CONNECTABLE ||
                 device.connectionState == DeviceConnectionState.ADVERTISING_NOT_CONNECTABLE
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
@@ -29,16 +29,17 @@ package inc.combustion.framework.ble.device
 
 import android.bluetooth.BluetoothAdapter
 import androidx.lifecycle.LifecycleOwner
+import com.juul.kable.Advertisement
 import inc.combustion.framework.ble.scanning.BaseAdvertisingData
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.service.CombustionProductType
 
 internal open class DeviceInformationBleDevice(
     mac: String,
-    type: CombustionProductType,
+    advertisement: CombustionAdvertisingData,
     owner: LifecycleOwner,
     adapter: BluetoothAdapter
-) : BleDevice(mac, type, owner, adapter) {
+) : BleDevice(mac, advertisement, owner, adapter) {
 
     var serialNumber: String? = null
     var firmwareVersion: String? = null

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
@@ -31,17 +31,26 @@ import android.bluetooth.BluetoothAdapter
 import androidx.lifecycle.LifecycleOwner
 import inc.combustion.framework.ble.scanning.BaseAdvertisingData
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
+import inc.combustion.framework.service.CombustionProductType
 
 internal open class DeviceInformationBleDevice(
     mac: String,
+    type: CombustionProductType,
     owner: LifecycleOwner,
     adapter: BluetoothAdapter
-) : BleDevice(mac, owner, adapter) {
+) : BleDevice(mac, type, owner, adapter) {
 
     var serialNumber: String? = null
     var firmwareVersion: String? = null
     var hardwareRevision: String? = null
 
+
+    override fun disconnect() {
+        serialNumber = null
+        firmwareVersion = null
+        hardwareRevision = null
+        super.disconnect()
+    }
     suspend fun readSerialNumber() {
         if(isConnected.get()) {
             serialNumber = readSerialNumberCharacteristic()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
@@ -54,7 +54,7 @@ internal class ProbeBleDevice (
     owner: LifecycleOwner,
     private var probeAdvertisingData: CombustionAdvertisingData,
     adapter: BluetoothAdapter,
-    private val uart: UartBleDevice = UartBleDevice(mac, probeAdvertisingData.productType, owner, adapter),
+    private val uart: UartBleDevice = UartBleDevice(mac, probeAdvertisingData, owner, adapter),
 ) : ProbeBleDeviceBase() {
 
     companion object {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
@@ -31,13 +31,11 @@ import inc.combustion.framework.ble.ProbeStatus
 import inc.combustion.framework.ble.scanning.BaseAdvertisingData
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.ble.uart.LogResponse
-import inc.combustion.framework.service.DeviceConnectionState
-import inc.combustion.framework.service.ProbeColor
-import inc.combustion.framework.service.ProbeID
-import inc.combustion.framework.service.ProbePredictionMode
+import inc.combustion.framework.service.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import java.util.concurrent.atomic.AtomicBoolean
 
 typealias LinkID = String
 
@@ -79,9 +77,18 @@ internal abstract class ProbeBleDeviceBase() {
     abstract val rssi: Int
     abstract val connectionState: DeviceConnectionState
     abstract val isConnected: Boolean
+    abstract val isDisconnected: Boolean
+    abstract val isInRange: Boolean
+    abstract val isConnectable: Boolean
+
+    // device information service
+    abstract val deviceInfoSerialNumber: String?
+    abstract val deviceInfoFirmwareVersion: String?
+    abstract val deviceInfoHardwareRevision: String?
 
     // meatnet
     abstract val hopCount: UInt
+    abstract val productType: CombustionProductType
 
     // connection management
     abstract fun connect()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
@@ -71,9 +71,20 @@ internal class RepeatedProbeBleDevice (
             return uart.mac
         }
 
-    override val rssi = uart.rssi
-    override val connectionState = uart.connectionState
-    override val isConnected = uart.isConnected.get()
+    // ble properties
+    override val rssi: Int get() { return uart.rssi }
+    override val connectionState: DeviceConnectionState get() { return uart.connectionState }
+    override val isConnected: Boolean get() { return uart.isConnected.get() }
+    override val isDisconnected: Boolean get() { return uart.isDisconnected.get() }
+    override val isInRange: Boolean get() { return uart.isInRange.get() }
+    override val isConnectable: Boolean get() { return uart.isConnectable.get() }
+
+    // device information service values from the repeated probe's node.
+    override val deviceInfoSerialNumber: String? get() { return uart.serialNumber }
+    override val deviceInfoFirmwareVersion: String? get() { return uart.firmwareVersion }
+    override val deviceInfoHardwareRevision: String? get() { return uart.hardwareRevision }
+
+    override val productType: CombustionProductType get() { return uart.productType}
 
     override val hopCount: UInt
         get() {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
@@ -31,6 +31,7 @@ package inc.combustion.framework.ble.device
 import android.util.Log
 import androidx.lifecycle.lifecycleScope
 import inc.combustion.framework.LOG_TAG
+import inc.combustion.framework.ble.NOT_IMPLEMENTED
 import inc.combustion.framework.ble.scanning.BaseAdvertisingData
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.ble.uart.Request
@@ -152,16 +153,20 @@ internal class RepeatedProbeBleDevice (
         TODO()
     }
 
-    override suspend fun readSerialNumber() {
-        TODO()
+    override suspend fun readSerialNumber() = uart.readSerialNumber()
+    override suspend fun readFirmwareVersion() = uart.readFirmwareVersion()
+    override suspend fun readHardwareRevision() = uart.readHardwareRevision()
+
+    suspend fun readProbeSerialNumber() {
+        NOT_IMPLEMENTED("Not able to read probe firmware serial number over meatnet")
     }
 
-    override suspend fun readFirmwareVersion() {
-        TODO()
+    suspend fun readProbeFirmwareVersion() {
+        NOT_IMPLEMENTED("Not able to read probe firmware version over meatnet")
     }
 
-    override suspend fun readHardwareRevision() {
-        TODO()
+    suspend fun readProbeHardwareRevision() {
+        NOT_IMPLEMENTED("Not able to read probe hardware rev over meatnet")
     }
 
     override fun observeAdvertisingPackets(serialNumberFilter: String, macFilter: String, callback: (suspend (advertisement: CombustionAdvertisingData) -> Unit)?) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
@@ -43,10 +43,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 internal open class UartBleDevice(
     mac: String,
-    type: CombustionProductType,
+    advertisement: CombustionAdvertisingData,
     owner: LifecycleOwner,
     adapter: BluetoothAdapter
-) : DeviceInformationBleDevice(mac, type, owner, adapter) {
+) : DeviceInformationBleDevice(mac, advertisement, owner, adapter) {
 
     class MessageCompletionHandler {
         private val waiting = AtomicBoolean(false)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
@@ -43,9 +43,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 internal open class UartBleDevice(
     mac: String,
+    type: CombustionProductType,
     owner: LifecycleOwner,
     adapter: BluetoothAdapter
-) : DeviceInformationBleDevice(mac, owner, adapter) {
+) : DeviceInformationBleDevice(mac, type, owner, adapter) {
 
     class MessageCompletionHandler {
         private val waiting = AtomicBoolean(false)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -497,6 +497,13 @@ class DeviceManager(
      */
     fun stopDfuMode() = service.stopDfuMode()
 
+    /**
+     * State flow containing the firmware details for all nodes on the network.
+     */
+    fun getNetworkFirmwareState(): StateFlow<FirmwareState>? {
+        return service.networkManager?.firmwareUpdateState
+    }
+
     private fun probeDataToCsv(probe: Probe?, probeData: List<LoggedProbeDataPoint>?, appNameAndVersion: String): Pair<String, String> {
         val csvVersion = 3
         val sb = StringBuilder()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/NodeFirmwareState.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/NodeFirmwareState.kt
@@ -1,0 +1,42 @@
+/*
+ * Project: Combustion Inc. Android Example
+ * File: NodeFirmwareState.kt
+ * Author:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.service
+
+import inc.combustion.framework.ble.device.DeviceID
+
+data class FirmwareState(
+    val nodes: List<Node>
+) {
+    data class Node(
+        val id: DeviceID,
+        val type: CombustionProductType,
+        val firmwareVersion: String
+    )
+}
+


### PR DESCRIPTION
- Create DataLinkArbitrator
- Heuristics to determine if a device should be connected to or disconnected from.
- Connection and Disconnection
- Read Device Information on Connection and publish.
- Flow for publishing node firmware details upon connection.
- MeatNet: automatic connection and reconnection to timers.
- Auto-Reconnect: !MeatNet with autoReconnect = true, automatic reconnect after framework call to connect.  Continue to reconnect until framework call disconnect.