### PR TITLE
DROID-169: Meatnet add handling of session info, fw, hw, and model info and DROID-168

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -306,7 +306,7 @@ internal class ProbeManager(
 
             // event out the invalid session info, fw version, and hardware revision.
             _probe.value = _probe.value.copy(
-                baseDevice = _probe.value.baseDevice.copy(fwVersion = null, hwRevision = null),
+                baseDevice = _probe.value.baseDevice.copy(fwVersion = null, hwRevision = null, modelInformation = null),
                 sessionInfo = null,
             )
         }
@@ -348,11 +348,14 @@ internal class ProbeManager(
                     is RepeatedProbeBleDevice -> device.readProbeFirmwareVersion()
                 }
             }
-            // TODO: MeatNet does not support reading serial number
-//            device.deviceInfoSerialNumber ?: run {
-//                didReadDeviceInfo = true
-//                device.readSerialNumber()
-//            }
+
+            device.deviceInfoSerialNumber ?: run {
+                didReadDeviceInfo = true
+                when (device) {
+                    is ProbeBleDevice -> device.readSerialNumber()
+                }
+            }
+
             device.deviceInfoHardwareRevision ?: run {
                 didReadDeviceInfo = true
                 when (device) {
@@ -377,7 +380,6 @@ internal class ProbeManager(
                     _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(
                         fwVersion = device.deviceInfoFirmwareVersion,
                         hwRevision = device.deviceInfoHardwareRevision,
-                        // TODO: Should we be updating this baseDevice modelInformation or should this be the repeater device modelInformation?
                         modelInformation = device.deviceInfoModelInformation
                     ))
                 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -347,7 +347,6 @@ internal class ProbeManager(
                     is ProbeBleDevice -> device.readFirmwareVersion()
                     is RepeatedProbeBleDevice -> device.readProbeFirmwareVersion()
                 }
-//                device.readFirmwareVersion()
             }
             // TODO: MeatNet does not support reading serial number
 //            device.deviceInfoSerialNumber ?: run {
@@ -360,7 +359,6 @@ internal class ProbeManager(
                     is ProbeBleDevice -> device.readHardwareRevision()
                     is RepeatedProbeBleDevice -> device.readProbeHardwareRevision()
                 }
-//                device.readHardwareRevision()
             }
         }.invokeOnCompletion {
             // if we read any of the device information characteristics above

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -376,7 +376,9 @@ internal class ProbeManager(
                 if(arbitrator.shouldUpdateOnDeviceInfoRead(device)) {
                     _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(
                         fwVersion = device.deviceInfoFirmwareVersion,
-                        hwRevision = device.deviceInfoHardwareRevision
+                        hwRevision = device.deviceInfoHardwareRevision,
+                        // TODO: Should we be updating this baseDevice modelInformation or should this be the repeater device modelInformation?
+                        modelInformation = device.deviceInfoModelInformation
                     ))
                 }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -360,6 +360,14 @@ internal class ProbeManager(
                     is RepeatedProbeBleDevice -> device.readProbeHardwareRevision()
                 }
             }
+
+            device.deviceInfoModelInformation ?: run {
+                didReadDeviceInfo = true
+                when (device) {
+                    is ProbeBleDevice -> device.readModelInformation()
+                    is RepeatedProbeBleDevice -> device.readProbeModelInformation()
+                }
+            }
         }.invokeOnCompletion {
             // if we read any of the device information characteristics above
             if(didReadDeviceInfo) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/BleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/BleDevice.kt
@@ -84,6 +84,10 @@ internal open class BleDevice (
             service = DEV_INFO_SERVICE_UUID_STRING,
             characteristic = "00002A27-0000-1000-8000-00805F9B34FB"
         )
+        private val MODEL_INFO_CHARACTERISTIC = characteristicOf(
+            service = DEV_INFO_SERVICE_UUID_STRING,
+            characteristic = "00002A24-0000-1000-8000-00805F9B34FB"
+        )
     }
 
     private val mutex = Mutex()
@@ -314,6 +318,9 @@ internal open class BleDevice (
 
     protected suspend fun readHardwareRevisionCharacteristic(): String? =
         readCharacteristic(HW_REVISION_CHARACTERISTIC, "remote hardware revision")?.toString(Charsets.UTF_8)
+
+    protected suspend fun readModelNumberCharacteristic(): String? =
+        readCharacteristic(MODEL_INFO_CHARACTERISTIC, "remote model info")?.toString(Charsets.UTF_8)
 
     private suspend fun readCharacteristic(
         characteristic: Characteristic,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
@@ -31,6 +31,7 @@ import android.bluetooth.BluetoothAdapter
 import androidx.lifecycle.LifecycleOwner
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.service.FirmwareVersion
+import inc.combustion.framework.service.ModelInformation
 
 internal open class DeviceInformationBleDevice(
     mac: String,
@@ -42,6 +43,7 @@ internal open class DeviceInformationBleDevice(
     var serialNumber: String? = null
     var firmwareVersion: FirmwareVersion? = null
     var hardwareRevision: String? = null
+    var modelInformation: ModelInformation? = null
 
 
     override fun disconnect() {
@@ -67,6 +69,14 @@ internal open class DeviceInformationBleDevice(
     suspend fun readHardwareRevision() {
         if(isConnected.get()) {
             hardwareRevision = readHardwareRevisionCharacteristic()
+        }
+    }
+
+    suspend fun readModelInformation() {
+        if(isConnected.get()) {
+            val info = readModelNumberCharacteristic()
+            // break up model number into sku and manufacturing lot
+            modelInformation = ModelInformation.fromString(info)
         }
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
@@ -74,9 +74,9 @@ internal open class DeviceInformationBleDevice(
 
     suspend fun readModelInformation() {
         if(isConnected.get()) {
-            val info = readModelNumberCharacteristic()
-            // break up model number into sku and manufacturing lot
-            modelInformation = ModelInformation.fromString(info)
+            modelInformation = readModelNumberCharacteristic()?.let { infoString ->
+                ModelInformation.fromString(infoString)
+            }
         }
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
@@ -92,6 +92,7 @@ internal class ProbeBleDevice (
     override val deviceInfoSerialNumber: String? get() { return uart.serialNumber }
     override val deviceInfoFirmwareVersion: FirmwareVersion? get() { return uart.firmwareVersion }
     override val deviceInfoHardwareRevision: String? get() { return uart.hardwareRevision }
+    override val deviceInfoModelInformation: ModelInformation? get() { return uart.modelInformation }
 
     override val productType: CombustionProductType get() { return uart.productType}
 
@@ -147,6 +148,7 @@ internal class ProbeBleDevice (
     override suspend fun readSerialNumber() = uart.readSerialNumber()
     override suspend fun readFirmwareVersion() = uart.readFirmwareVersion()
     override suspend fun readHardwareRevision() = uart.readHardwareRevision()
+    override suspend fun readModelInformation() = uart.readModelInformation()
 
     override fun observeAdvertisingPackets(serialNumberFilter: String, macFilter: String, callback: (suspend (advertisement: CombustionAdvertisingData) -> Unit)?) {
         uart.observeAdvertisingPackets(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
@@ -81,6 +81,7 @@ internal abstract class ProbeBleDeviceBase() {
     abstract val deviceInfoSerialNumber: String?
     abstract val deviceInfoFirmwareVersion: FirmwareVersion?
     abstract val deviceInfoHardwareRevision: String?
+    abstract val deviceInfoModelInformation: ModelInformation?
 
     // meatnet
     abstract val hopCount: UInt
@@ -102,6 +103,7 @@ internal abstract class ProbeBleDeviceBase() {
     abstract suspend fun readSerialNumber()
     abstract suspend fun readFirmwareVersion()
     abstract suspend fun readHardwareRevision()
+    abstract suspend fun readModelInformation()
 
     // probe status updates
     abstract fun observeProbeStatusUpdates(callback: (suspend (status: ProbeStatus) -> Unit)? = null)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
@@ -89,6 +89,7 @@ internal class RepeatedProbeBleDevice (
     override val deviceInfoSerialNumber: String? get() { return uart.serialNumber }
     override val deviceInfoFirmwareVersion: FirmwareVersion? get() { return uart.firmwareVersion }
     override val deviceInfoHardwareRevision: String? get() { return uart.hardwareRevision }
+    override val deviceInfoModelInformation: ModelInformation? get() { return uart.modelInformation }
 
     override val productType: CombustionProductType get() { return uart.productType}
 
@@ -118,6 +119,7 @@ internal class RepeatedProbeBleDevice (
 
         processUartMessages()
     }
+
 
     override fun connect() = uart.connect()
     override fun disconnect() = uart.disconnect()
@@ -152,6 +154,7 @@ internal class RepeatedProbeBleDevice (
     override suspend fun readSerialNumber() = uart.readSerialNumber()
     override suspend fun readFirmwareVersion() = uart.readFirmwareVersion()
     override suspend fun readHardwareRevision() = uart.readHardwareRevision()
+    override suspend fun readModelInformation() = uart.readModelInformation()
 
     suspend fun readProbeSerialNumber() {
         NOT_IMPLEMENTED("Not able to read probe firmware serial number over meatnet")
@@ -187,6 +190,17 @@ internal class RepeatedProbeBleDevice (
             }
         }
         sendUartRequest(NodeReadHardwareRevisionRequest(probeSerialNumber))
+    }
+
+    suspend fun readProbeModelInformation() {
+        Log.d(LOG_TAG, "readProbeModelInformation")
+        probeModelInfoHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
+            if (success) {
+                val resp = response as NodeReadModelInfoResponse
+                uart.modelInformation = resp.modelInfo
+            }
+        }
+        sendUartRequest(NodeReadModelInfoRequest(probeSerialNumber))
     }
 
     override fun observeAdvertisingPackets(serialNumberFilter: String, macFilter: String, callback: (suspend (advertisement: CombustionAdvertisingData) -> Unit)?) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadHardwareRevisionRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadHardwareRevisionRequest.kt
@@ -1,7 +1,7 @@
 /*
  * Project: Combustion Inc. Android Framework
  * File: NodeReadHardwareRevisionRequest.kt
- * Author:
+ * Author: https://github.com/angrygorilla
  *
  * MIT License
  *

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadHardwareRevisionResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadHardwareRevisionResponse.kt
@@ -1,7 +1,7 @@
 /*
  * Project: Combustion Inc. Android Framework
  * File: NodeReadHardwareRevisionResponse.kt
- * Author:
+ * Author: https://github.com/angrygorilla
  *
  * MIT License
  *

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsRequest.kt
@@ -1,7 +1,7 @@
 /*
  * Project: Combustion Inc. Android Framework
  * File: NodeReadLogsRequest.kt
- * Author:
+ * Author: https://github.com/angrygorilla
  *
  * MIT License
  *

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsResponse.kt
@@ -1,7 +1,7 @@
 /*
  * Project: Combustion Inc. Android Framework
  * File: NodeReadLogsResponse.kt
- * Author:
+ * Author: https://github.com/angrygorilla
  *
  * MIT License
  *

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoRequest.kt
@@ -31,7 +31,7 @@ package inc.combustion.framework.ble.uart.meatnet
 import inc.combustion.framework.ble.putLittleEndianUInt32At
 
 internal class NodeReadModelInfoRequest (
-    serialNumber: UInt,
+    serialNumber: String,
 ) : NodeRequest(
     populatePayload(serialNumber),
     NodeMessageType.PROBE_MODEL_INFORMATION
@@ -43,13 +43,13 @@ internal class NodeReadModelInfoRequest (
          * Helper function that builds up payload of request.
          */
         fun populatePayload(
-            serialNumber: UInt
+            serialNumber: String
         ) : UByteArray {
 
             val payload = UByteArray(PAYLOAD_LENGTH.toInt()) { 0u }
 
             // Add serial number to payload
-            payload.putLittleEndianUInt32At(0, serialNumber)
+            payload.putLittleEndianUInt32At(0, serialNumber.toLong(radix = 16).toUInt())
 
             return payload
         }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoRequest.kt
@@ -1,7 +1,7 @@
 /*
  * Project: Combustion Inc. Android Framework
  * File: NodeReadModelInfoRequest.kt
- * Author:
+ * Author: https://github.com/angrygorilla
  *
  * MIT License
  *

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoResponse.kt
@@ -1,7 +1,7 @@
 /*
  * Project: Combustion Inc. Android Framework
  * File: NodeReadModelInfoResponse.kt
- * Author:
+ * Author: https://github.com/angrygorilla
  *
  * MIT License
  *

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoResponse.kt
@@ -29,10 +29,11 @@
 package inc.combustion.framework.ble.uart.meatnet
 
 import inc.combustion.framework.ble.getLittleEndianUInt32At
+import inc.combustion.framework.service.ModelInformation
 
 internal class NodeReadModelInfoResponse (
-    serialNumber: UInt,
-    modelInfo: String,
+    val serialNumber: UInt,
+    val modelInfo: ModelInformation,
     success: Boolean,
     requestId: UInt,
     responseId: UInt,
@@ -61,8 +62,8 @@ internal class NodeReadModelInfoResponse (
             }
 
             val serialNumber = payload.getLittleEndianUInt32At(PAYLOAD_LENGTH.toInt())
-            val modelInfoRaw = payload.copyOfRange(HEADER_SIZE.toInt() + 4, HEADER_SIZE.toInt() + 54)
-            val modelInfo = String(modelInfoRaw.toByteArray(), Charsets.UTF_8).trim('\u0000')
+            val modelInformationString = String(payload.copyOfRange(HEADER_SIZE.toInt() + 4, HEADER_SIZE.toInt() + 54).toByteArray(), Charsets.UTF_8).trim('\u0000')
+            val modelInfo = ModelInformation.fromString(modelInformationString)
 
             return NodeReadModelInfoResponse(
                 serialNumber,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoRequest.kt
@@ -31,7 +31,7 @@ package inc.combustion.framework.ble.uart.meatnet
 import inc.combustion.framework.ble.putLittleEndianUInt32At
 
 internal class NodeReadSessionInfoRequest (
-    serialNumber: UInt,
+    serialNumber: String,
 ) : NodeRequest(
     populatePayload(serialNumber),
     NodeMessageType.SESSION_INFO
@@ -44,13 +44,13 @@ internal class NodeReadSessionInfoRequest (
             * Helper function that builds up payload of request.
             */
             fun populatePayload(
-                serialNumber: UInt
+                serialNumber: String
             ) : UByteArray {
 
                 val payload = UByteArray(PAYLOAD_LENGTH.toInt()) { 0u }
 
                 // Add serial number to payload
-                payload.putLittleEndianUInt32At(0, serialNumber)
+                payload.putLittleEndianUInt32At(0, serialNumber.toLong(radix = 16).toUInt())
                 return payload
             }
         }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoResponse.kt
@@ -1,7 +1,7 @@
 /*
  * Project: Combustion Inc. Android Framework
  * File: NodeReadSessionInfoResponse.kt
- * Author:
+ * Author: https://github.com/angrygorilla
  *
  * MIT License
  *

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -127,16 +127,48 @@ internal open class NodeResponse(
 //                    )
 //                }
 
-//                NodeMessageType.SESSION_INFO -> {
-//                    return NodeSessionInfoResponse.fromRaw(
-//                        data,
-//                        success,
-//                        payloadLength
-//                    )
-//                }
+                NodeMessageType.SESSION_INFO -> {
+                    return NodeReadSessionInfoResponse.fromData(
+                        data,
+                        success,
+                        requestId,
+                        responseId,
+                        payloadLength
+                    )
+                }
 
                 NodeMessageType.SET_PREDICTION -> {
                     return NodeSetPredictionResponse(
+                        success,
+                        requestId,
+                        responseId,
+                        payloadLength
+                    )
+                }
+
+                NodeMessageType.PROBE_FIRMWARE_REVISION -> {
+                    return NodeReadFirmwareRevisionResponse.fromData(
+                        data,
+                        success,
+                        requestId,
+                        responseId,
+                        payloadLength
+                    )
+                }
+
+                NodeMessageType.PROBE_HARDWARE_REVISION -> {
+                    return NodeReadHardwareRevisionResponse.fromData(
+                        data,
+                        success,
+                        requestId,
+                        responseId,
+                        payloadLength
+                    )
+                }
+
+                NodeMessageType.PROBE_MODEL_INFORMATION -> {
+                    return NodeReadModelInfoResponse.fromData(
+                        data,
                         success,
                         requestId,
                         responseId,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetPredictionRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetPredictionRequest.kt
@@ -32,7 +32,7 @@ import inc.combustion.framework.ble.putLittleEndianUInt32At
 import inc.combustion.framework.service.ProbePredictionMode
 
 internal class NodeSetPredictionRequest(
-    serialNumber: UInt,
+    serialNumber: String,
     setPointTemperatureC: Double,
     mode: ProbePredictionMode
 
@@ -46,7 +46,7 @@ internal class NodeSetPredictionRequest(
          * Helper function that builds up payload of request.
          */
         fun populatePayload(
-            serialNumber: UInt,
+            serialNumber: String,
             setPointTemperatureC: Double,
             mode: ProbePredictionMode
         ) : UByteArray {
@@ -54,7 +54,7 @@ internal class NodeSetPredictionRequest(
             val payload = UByteArray(PAYLOAD_LENGTH.toInt())
 
             // Add serial number to payload
-            payload.putLittleEndianUInt32At(0, serialNumber)
+            payload.putLittleEndianUInt32At(0, serialNumber.toLong(radix = 16).toUInt())
 
             // Encode prediction info in payload
             val converted = (setPointTemperatureC * 10.0).toUInt()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ModelInformation.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ModelInformation.kt
@@ -1,7 +1,7 @@
 /*
  * Project: Combustion Inc. Android Framework
- * File: Device.kt
- * Author: https://github.com/nick-sasquatch
+ * File: ModelInformation.kt
+ * Author:
  *
  * MIT License
  *
@@ -28,29 +28,27 @@
 
 package inc.combustion.framework.service
 
-import inc.combustion.framework.ble.device.DeviceID
-
-/**
- * Representation of a Combustion device.
- *
- * @property serialNumber The device serial number.
- * @property mac The device's MAC address.
- * @property fwVersion The device's firmware version.
- * @property hwRevision The device's hardware revision.
- * @property modelInformation The device's model information which contains the SKU and manufacturing lot #.
- * @property rssi The BLE RSSI value.
- * @property productType The device product type.
- * @property connectionState The device's current BLE connection state.
- */
-data class Device(
-    val serialNumber: String = "",
-    val mac: String,
-    val fwVersion: FirmwareVersion? = null,
-    val hwRevision: String? = null,
-    val modelInformation: ModelInformation? = null,
-    val rssi: Int = 0,
-    val productType: CombustionProductType? = null,
-    val connectionState: DeviceConnectionState = DeviceConnectionState.DISCONNECTED,
+data class ModelInformation(
+    val sku: String,
+    val manufacturingLot: String
 ) {
-    val id: DeviceID = mac
+
+    companion object {
+        /**
+         * Converts this model information string into a [ModelInformation] object, which includes the
+         * SKU and manufacturing lot.
+         */
+        fun fromString(modelInformationString: String?): ModelInformation {
+            return if(modelInformationString == null) {
+                ModelInformation("", "")
+            } else {
+                val split = modelInformationString.split(":")
+                if(split.size == 2) {
+                    ModelInformation(split[0], split[1])
+                } else {
+                    ModelInformation("", "")
+                }
+            }
+        }
+    }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
@@ -92,6 +92,7 @@ data class Probe(
     val mac = baseDevice.mac
     val fwVersion = baseDevice.fwVersion
     val hwRevision = baseDevice.hwRevision
+    val modelInformation = baseDevice.modelInformation
     val rssi = baseDevice.rssi
     val connectionState = baseDevice.connectionState
 


### PR DESCRIPTION
- Added session info, firmware revision, hardware revision, and model information over UART on connection handling for Node devices
- Added Model Information data class
- Added saving model Information after connected state
