### PR TITLE
DROID-179: MeatNet Log Transfer

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -33,6 +33,7 @@ import inc.combustion.framework.ble.device.ProbeBleDevice
 import inc.combustion.framework.ble.device.ProbeBleDeviceBase
 import inc.combustion.framework.ble.device.RepeatedProbeBleDevice
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
+import inc.combustion.framework.service.DeviceConnectionState
 import inc.combustion.framework.service.DeviceManager
 
 internal class DataLinkArbitrator(
@@ -102,10 +103,6 @@ internal class DataLinkArbitrator(
 
     fun isConnectedToMeatNet(): Boolean {
         return getPreferredMeatNetLink() != null
-    }
-
-    private fun isConnectedToAnyRepeater(): Boolean {
-        return repeatedProbeBleDevices.firstOrNull { it.isConnected } != null
     }
 
     fun getNodesNeedingConnection(fromApiCall: Boolean = false): List<DeviceInformationBleDevice> {
@@ -230,6 +227,20 @@ internal class DataLinkArbitrator(
 
     fun shouldUpdateOnRemoteRssi(device: ProbeBleDeviceBase, rssi: Int): Boolean {
         return arbitrateConnected(device)
+    }
+
+    fun isAbleToSendUartMessages(): Boolean {
+        // MIW
+        return if(settings.meatNetEnabled) {
+            isConnectedToMeatNet()
+        }
+        else {
+            getDirectLink() != null
+        }
+    }
+
+    private fun isConnectedToAnyRepeater(): Boolean {
+        return repeatedProbeBleDevices.firstOrNull { it.isConnected } != null
     }
 
     private fun arbitrateConnected(device: ProbeBleDeviceBase): Boolean {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -44,17 +44,18 @@ internal class DataLinkArbitrator(
         private const val USE_STATIC_LINK: Boolean = false
     }
 
-    // direct ble link to probe
-    private var probeBleDevice: ProbeBleDevice? = null
-
-    // meatnet links to probe
-    private val repeatedProbeBleDevices = mutableListOf<RepeatedProbeBleDevice>()
-
     // meatnet network nodes
     private val networkNodes = hashMapOf<DeviceID, DeviceInformationBleDevice>()
 
     // advertising data arbitration
     private val advertisingArbitrator = AdvertisingArbitrator()
+
+    // direct ble link to probe
+    var probeBleDevice: ProbeBleDevice? = null
+        private set
+
+    // meatnet links to probe
+    val repeatedProbeBleDevices = mutableListOf<RepeatedProbeBleDevice>()
 
     val directLink: ProbeBleDevice?
         get() {
@@ -82,17 +83,6 @@ internal class DataLinkArbitrator(
             ).firstOrNull {
                 it.isConnected && it.connectionState != DeviceConnectionState.NO_ROUTE
             }
-        }
-
-    val hasUartRoute: Boolean
-        get() {
-            if(directLink?.isConnected == true) {
-                return true
-            }
-
-            return repeatedProbeBleDevices.firstOrNull {
-                it.isConnected && it.connectionState != DeviceConnectionState.NO_ROUTE
-            } != null
         }
 
     val hasNoUartRoute: Boolean

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -200,10 +200,6 @@ internal class DataLinkArbitrator(
         return false
     }
 
-    fun shouldUpdateOnDeviceInfoRead(device: ProbeBleDeviceBase): Boolean {
-        return device is ProbeBleDevice
-    }
-
     fun shouldUpdateOnOutOfRange(device: ProbeBleDeviceBase): Boolean {
         return device is ProbeBleDevice && !settings.meatNetEnabled
         // TODO: Else, Decide how to handle with Multi-Node MeatNet

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -229,7 +229,6 @@ internal class ProbeManager(
     }
 
     fun sendLogRequest(startSequenceNumber: UInt, endSequenceNumber: UInt) {
-        //Log.e("MATT", "Requesting Logs: $startSequenceNumber to $endSequenceNumber (${endSequenceNumber - startSequenceNumber}) ($uploadState)")
         arbitrator.getPreferredMeatNetLink()?.sendLogRequest(startSequenceNumber, endSequenceNumber) {
             _logResponseFlow.emit(it)
         }
@@ -399,13 +398,11 @@ internal class ProbeManager(
             if(didReadDeviceInfo) {
 
                 // if we should update the current external state of the probe base on device info data
-                if(arbitrator.shouldUpdateOnDeviceInfoRead(device)) {
-                    _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(
-                        fwVersion = device.deviceInfoFirmwareVersion,
-                        hwRevision = device.deviceInfoHardwareRevision,
-                        modelInformation = device.deviceInfoModelInformation
-                    ))
-                }
+                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(
+                    fwVersion = device.deviceInfoFirmwareVersion,
+                    hwRevision = device.deviceInfoHardwareRevision,
+                    modelInformation = device.deviceInfoModelInformation
+                ))
 
                 device.deviceInfoFirmwareVersion?.let {
                     dfuConnectedNodeCallback(FirmwareState.Node(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -397,9 +397,9 @@ internal class ProbeManager(
         // messages, and transition the upload state to Unavailable.  Null SessionInfo
         // so that it can be requested again when a route is established
         if(arbitrator.hasNoUartRoute && uploadState != ProbeUploadState.Unavailable) {
+            logTransferCompleteCallback()
             sessionInfo = null
             uploadState = ProbeUploadState.Unavailable
-            logTransferCompleteCallback()
         }
 
         // use the arbitrated connection state, fw version, hw revision, model information

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/BleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/BleDevice.kt
@@ -229,7 +229,6 @@ internal open class BleDevice (
                         }
                         isInRange.set(false)
                         isConnectable.set(false)
-                        isDisconnected.set(true)
                     }
 
                     callback?.let {
@@ -352,7 +351,7 @@ internal open class BleDevice (
 
         // if the device is advertising as connectable, advertising as non-connectable,
         // currently disconnected, or currently out of range then it's new state is the
-        // advertising state determined above. otherwise, (connected, connected or
+        // advertising state determined above. otherwise, (connected, connecting or
         // disconnecting) the state is unchanged by the advertising packet.
         connectionState = when(connectionState) {
             DeviceConnectionState.ADVERTISING_CONNECTABLE -> advertisingState

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DfuBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DfuBleDevice.kt
@@ -147,6 +147,7 @@ internal class DfuBleDevice(
                     )
                 }
             }
+            DeviceConnectionState.NO_ROUTE,
             DeviceConnectionState.ADVERTISING_NOT_CONNECTABLE,
             DeviceConnectionState.OUT_OF_RANGE -> {
                 _state.value = DfuState.NotReady(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
@@ -31,6 +31,8 @@ package inc.combustion.framework.ble.device
 import android.util.Log
 import androidx.lifecycle.lifecycleScope
 import inc.combustion.framework.LOG_TAG
+import inc.combustion.framework.ble.IdleMonitor
+import inc.combustion.framework.ble.NOT_IMPLEMENTED
 import inc.combustion.framework.ble.ProbeStatus
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.ble.uart.LogResponse
@@ -42,6 +44,8 @@ import inc.combustion.framework.ble.uart.meatnet.NodeUARTMessage
 import inc.combustion.framework.ble.uart.meatnet.NodeReadSessionInfoRequest
 import inc.combustion.framework.service.*
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 internal class RepeatedProbeBleDevice (
@@ -54,6 +58,9 @@ internal class RepeatedProbeBleDevice (
 
     private var probeStatusCallback: (suspend (status: ProbeStatus) -> Unit)? = null
     private var logResponseCallback: (suspend (LogResponse) -> Unit)? = null
+
+    // activate this monitor whenever the link to the probe is used, except for session info
+    private val routeMonitor = IdleMonitor()
 
     override val advertisement: CombustionAdvertisingData?
         get() {
@@ -77,11 +84,21 @@ internal class RepeatedProbeBleDevice (
 
     // ble properties
     override val rssi: Int get() { return uart.rssi }
-    override val connectionState: DeviceConnectionState get() { return uart.connectionState }
     override val isConnected: Boolean get() { return uart.isConnected.get() }
     override val isDisconnected: Boolean get() { return uart.isDisconnected.get() }
     override val isInRange: Boolean get() { return uart.isInRange.get() }
     override val isConnectable: Boolean get() { return uart.isConnectable.get() }
+
+    // repeater connection state
+    private var routeIsAvailable = true
+    private var _connectionState: DeviceConnectionState = uart.connectionState
+    override val connectionState: DeviceConnectionState
+        get() {
+            return when(_connectionState) {
+                DeviceConnectionState.CONNECTED -> if(routeIsAvailable) _connectionState else DeviceConnectionState.NO_ROUTE
+                else -> _connectionState
+            }
+        }
 
     // device information service values from the repeated probe's node.
     override val deviceInfoSerialNumber: String? get() { return uart.serialNumber }
@@ -112,37 +129,42 @@ internal class RepeatedProbeBleDevice (
     private val probeHardwareRevisionHandler = UartBleDevice.MessageCompletionHandler()
     private val probeModelInfoHandler = UartBleDevice.MessageCompletionHandler()
 
+    // base connection state callback
+    private var connectionStateCallback: (suspend (newConnectionState: DeviceConnectionState) -> Unit)? = null
+
     init {
         advertisementForProbe[advertisement.probeSerialNumber] = advertisement
 
         processUartMessages()
+        monitorMeatNetRoute()
     }
 
     override fun connect() = uart.connect()
     override fun disconnect() = uart.disconnect()
 
     override fun sendSessionInformationRequest(callback: ((Boolean, Any?) -> Unit)?)  {
-        // see ProbeUartBleDevice
         sessionInfoHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, callback)
         sendUartRequest(NodeReadSessionInfoRequest(probeSerialNumber))
     }
 
     override fun sendSetProbeColor(color: ProbeColor, callback: ((Boolean, Any?) -> Unit)?) {
-        // see ProbeUartBleDevice
-        TODO()
+        routeMonitor.activity()
+        NOT_IMPLEMENTED("Not able to set probe color over MeatNet")
     }
 
     override fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)?) {
-        // see ProbeUartBleDevice
-        TODO()
+        routeMonitor.activity()
+        NOT_IMPLEMENTED("Not able to set probe ID over MeatNet")
     }
 
     override fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, callback: ((Boolean, Any?) -> Unit)?) {
+        routeMonitor.activity()
         setPredictionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, callback)
         sendUartRequest(NodeSetPredictionRequest(probeSerialNumber, setPointTemperatureC, mode))
     }
 
     override fun sendLogRequest(minSequence: UInt, maxSequence: UInt, callback: (suspend (LogResponse) -> Unit)?) {
+        routeMonitor.activity()
         logResponseCallback = callback
         sendUartRequest(NodeReadLogsRequest(probeSerialNumber, minSequence, maxSequence))
     }
@@ -154,6 +176,7 @@ internal class RepeatedProbeBleDevice (
 
     suspend fun readProbeFirmwareVersion() {
         val channel = Channel<Unit>(0)
+        routeMonitor.activity()
         probeFirmwareRevisionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
             if (success) {
                 val resp = response as NodeReadFirmwareRevisionResponse
@@ -170,6 +193,7 @@ internal class RepeatedProbeBleDevice (
 
     suspend fun readProbeHardwareRevision() {
         val channel = Channel<Unit>(0)
+        routeMonitor.activity()
         probeHardwareRevisionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
             if (success) {
                 val resp = response as NodeReadHardwareRevisionResponse
@@ -186,6 +210,7 @@ internal class RepeatedProbeBleDevice (
 
     suspend fun readProbeModelInformation() {
         val channel = Channel<Unit>(0)
+        routeMonitor.activity()
         probeModelInfoHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
             if (success) {
                 val resp = response as NodeReadModelInfoResponse
@@ -214,7 +239,11 @@ internal class RepeatedProbeBleDevice (
 
     override fun observeRemoteRssi(callback: (suspend (rssi: Int) -> Unit)?) = uart.observeRemoteRssi(callback)
     override fun observeOutOfRange(timeout: Long, callback: (suspend () -> Unit)?) = uart.observeOutOfRange(timeout, callback)
-    override fun observeConnectionState(callback: (suspend (newConnectionState: DeviceConnectionState) -> Unit)?) = uart.observeConnectionState(callback)
+
+    override fun observeConnectionState(callback: (suspend (newConnectionState: DeviceConnectionState) -> Unit)?) {
+        connectionStateCallback = callback
+        uart.observeConnectionState(this::baseConnectionStateHandler)
+    }
 
     override fun observeProbeStatusUpdates(callback: (suspend (status: ProbeStatus) -> Unit)?) {
         probeStatusCallback = callback
@@ -274,19 +303,33 @@ internal class RepeatedProbeBleDevice (
         observeUartMessages { messages ->
             for (message in messages) {
                 when (message) {
-
                     // Unsupported Messages
-//                  is NodeSetColorResponse -> setColorHandler.handled(response.success, null)
-//                  is NodeSetIDResponse -> setIdHandler.handled(response.success, null)
+                    // is NodeSetColorResponse -> setColorHandler.handled(response.success, null)
+                    // is NodeSetIDResponse -> setIdHandler.handled(response.success, null)
 
                     // Repeated Responses
-                    is NodeReadLogsResponse -> handleLogResponse(message)
+                    is NodeReadLogsResponse -> {
+                        routeMonitor.activity()
+                        handleLogResponse(message)
+                    }
 
-                    // Syncronous Requests that are responded to with a single message
-                    is NodeSetPredictionResponse -> setPredictionHandler.handled(message.success, null)
-                    is NodeReadFirmwareRevisionResponse -> probeFirmwareRevisionHandler.handled(message.success, message)
-                    is NodeReadHardwareRevisionResponse -> probeHardwareRevisionHandler.handled(message.success, message)
-                    is NodeReadModelInfoResponse -> probeModelInfoHandler.handled(message.success, message)
+                    // Synchronous Requests that are responded to with a single message
+                    is NodeSetPredictionResponse -> {
+                        routeMonitor.activity()
+                        setPredictionHandler.handled(message.success, null)
+                    }
+                    is NodeReadFirmwareRevisionResponse -> {
+                        routeMonitor.activity()
+                        probeFirmwareRevisionHandler.handled(message.success, message)
+                    }
+                    is NodeReadHardwareRevisionResponse -> {
+                        routeMonitor.activity()
+                        probeHardwareRevisionHandler.handled(message.success, message)
+                    }
+                    is NodeReadModelInfoResponse -> {
+                        routeMonitor.activity()
+                        probeModelInfoHandler.handled(message.success, message)
+                    }
 
                     /// Async Requests that are Broadcast on certain events from a Node
                     is NodeProbeStatusRequest -> handleProbeStatusRequest(message)
@@ -294,5 +337,54 @@ internal class RepeatedProbeBleDevice (
                 }
             }
         }
+    }
+
+    private fun monitorMeatNetRoute() {
+        uart.jobManager.addJob(uart.owner.lifecycleScope.launch {
+            val channel = Channel<Unit>(0)
+
+            // until this coroutine is cancelled
+            while(isActive) {
+                // delay to poll again on next period
+                delay(PING_RATE_MS)
+
+                // if we are connected to the repeater, and the link has been idle for sufficient time.
+                if(uart.connectionState == DeviceConnectionState.CONNECTED && routeMonitor.isIdle(IDLE_LINK_TIMEOUT)) {
+                    val state = connectionState
+
+                    // send session information request to ping the endpoint and determine if there is a route
+                    sendSessionInformationRequest { status, _ ->
+                        // keep track of the status of the ping
+                        routeIsAvailable = status
+
+                        // use channel to signal that this response handler block is done
+                        uart.owner.lifecycleScope.launch { channel.send(Unit) }
+                    }
+
+                    // block this polling coroutine until the response handler is done.
+                    channel.receive()
+
+                    // if we aren't able to ping, then event up that there is no route to the probe.
+                    if((state == DeviceConnectionState.NO_ROUTE || connectionState == DeviceConnectionState.NO_ROUTE) && state != connectionState) {
+                        connectionStateCallback?.let {
+                            Log.i(LOG_TAG, "Ping: New State $connectionState ($_connectionState)")
+                            uart.owner.lifecycleScope.launch {
+                                it(connectionState)
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    private suspend fun baseConnectionStateHandler(newConnectionState: DeviceConnectionState) {
+        _connectionState = newConnectionState
+        connectionStateCallback?.let { it(connectionState) }
+    }
+
+    companion object {
+        const val PING_RATE_MS = 1000L
+        const val IDLE_LINK_TIMEOUT = MESSAGE_RESPONSE_TIMEOUT_MS + 500L
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/LogResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/LogResponse.kt
@@ -40,7 +40,7 @@ import inc.combustion.framework.service.ProbeVirtualSensors
  * @constructor
  * Constructs the response from the byte array received over BLE from the UART service.
  *
- * @param data Data received over BLUE
+ * @param data Data received over BLE
  * @param success Base response status code.
  */
 internal class LogResponse(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
@@ -35,15 +35,10 @@ import inc.combustion.framework.service.HopCount
 internal class NodeProbeStatusRequest(
     requestId : UInt,
     payloadLength : UByte,
-    val serialNumber: UInt,
+    val serialNumber: String,
     val hopCount: HopCount,
     val probeStatus: ProbeStatus
 ) : NodeRequest(requestId, payloadLength) {
-
-    val serialNumberString: String
-        get() {
-            return Integer.toHexString(serialNumber.toInt()).uppercase()
-        }
 
     companion object {
         const val PAYLOAD_LENGTH: UByte = 35u
@@ -67,7 +62,7 @@ internal class NodeProbeStatusRequest(
             val serialNumber: UInt = data.getLittleEndianUInt32At(SERIAL_NUMBER_INDEX)
             val hopCount: HopCount = HopCount.fromUByte(data[HOP_COUNT_INDEX])
 
-            return NodeProbeStatusRequest(requestId, payloadLength, serialNumber, hopCount, probeStatus)
+            return NodeProbeStatusRequest(requestId, payloadLength, Integer.toHexString(serialNumber.toInt()).uppercase(), hopCount, probeStatus)
         }
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsRequest.kt
@@ -31,7 +31,7 @@ package inc.combustion.framework.ble.uart.meatnet
 import inc.combustion.framework.ble.putLittleEndianUInt32At
 
 internal class NodeReadLogsRequest(
-    serialNumber: UInt,
+    serialNumber: String,
     minSequence: UInt,
     maxSequence: UInt,
 ) : NodeRequest(
@@ -50,12 +50,12 @@ internal class NodeReadLogsRequest(
          * Helper function that builds up payload of request.
          */
         fun populatePayload(
-            serialNumber: UInt,
+            serialNumber: String,
             minSequence: UInt,
             maxSequence: UInt): UByteArray {
             val payload = UByteArray(PAYLOAD_LENGTH.toInt()) { 0u }
 
-            payload.putLittleEndianUInt32At(0, serialNumber)
+            payload.putLittleEndianUInt32At(0, serialNumber.toLong(radix = 16).toUInt())
             payload.putLittleEndianUInt32At(4, minSequence)
             payload.putLittleEndianUInt32At(8, maxSequence)
             return payload

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsResponse.kt
@@ -33,6 +33,7 @@ import inc.combustion.framework.service.PredictionLog
 import inc.combustion.framework.service.ProbeTemperatures
 
 internal class NodeReadLogsResponse(
+    val serialNumber: String,
     val sequenceNumber: UInt,
     val temperatures: ProbeTemperatures,
     val predictionLog: PredictionLog,
@@ -60,17 +61,18 @@ internal class NodeReadLogsResponse(
                 return null
             }
 
-            val serialNumber = payload.getLittleEndianUInt32At(HEADER_SIZE.toInt())
-            val sequenceNumber = payload.getLittleEndianUInt32At(HEADER_SIZE.toInt() + 4)
+            val serialNumber = payload.getLittleEndianUInt32At(HEADER_SIZE.toInt()).toString(radix = 16).uppercase()
+            val sequenceNumber = payload.getLittleEndianUInt32At((HEADER_SIZE + 4u).toInt())
             val rawTemperatures =
-                payload.sliceArray(HEADER_SIZE.toInt() + 8 until HEADER_SIZE.toInt() + 20)
+                payload.sliceArray((HEADER_SIZE + 8u).toInt() .. (HEADER_SIZE + 20u).toInt())
             val rawPredictionLog =
-                payload.sliceArray(HEADER_SIZE.toInt() + 21 until HEADER_SIZE.toInt() + 27)
+                payload.sliceArray((HEADER_SIZE + 21u ).toInt().. (HEADER_SIZE + 27u).toInt())
 
             val temperatures = ProbeTemperatures.fromRawData(rawTemperatures)
             val predictionLog = PredictionLog.fromRawData(rawPredictionLog)
 
             return NodeReadLogsResponse(
+                serialNumber,
                 sequenceNumber,
                 temperatures,
                 predictionLog,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoResponse.kt
@@ -33,6 +33,7 @@ import inc.combustion.framework.ble.getLittleEndianUInt32At
 import inc.combustion.framework.service.SessionInformation
 
 internal class NodeReadSessionInfoResponse (
+    val serialNumber: String,
     val sessionInformation: SessionInformation,
     success: Boolean,
     requestId: UInt,
@@ -60,12 +61,13 @@ internal class NodeReadSessionInfoResponse (
                 return null
             }
 
-            val serialNumber: UInt = payload.getLittleEndianUInt32At(HEADER_SIZE.toInt())
+            val serial = payload.getLittleEndianUInt32At(HEADER_SIZE.toInt()).toString(radix = 16).uppercase()
             val sessionID: UInt = payload.getLittleEndianUInt32At(HEADER_SIZE.toInt() + 4)
             val samplePeriod: UInt = payload.getLittleEndianUInt16At(HEADER_SIZE.toInt() + 8)
             val sessionInfo = SessionInformation(sessionID, samplePeriod)
 
             return NodeReadSessionInfoResponse(
+                serial,
                 sessionInfo,
                 success,
                 requestId,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
@@ -34,6 +34,7 @@ import inc.combustion.framework.ble.getCRC16CCITT
 import inc.combustion.framework.ble.getLittleEndianUInt32At
 import inc.combustion.framework.ble.putLittleEndianUInt32At
 import inc.combustion.framework.ble.putLittleEndianUShortAt
+import inc.combustion.framework.service.DebugSettings
 
 /**
  * Baseclass for UART request messages
@@ -101,6 +102,10 @@ internal open class NodeRequest() : NodeUARTMessage() {
                 }
 
                 else -> {
+                    if ( DebugSettings.DEBUG_LOG_MESSAGE_REQUESTS ) {
+                        Log.d(LOG_TAG, "NodeRequest: Unknown message type: $messageType")
+                    }
+
                     null
                 }
             }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -27,9 +27,12 @@
  */
 package inc.combustion.framework.ble.uart.meatnet
 
+import android.util.Log
+import inc.combustion.framework.LOG_TAG
 import inc.combustion.framework.ble.getCRC16CCITT
 import inc.combustion.framework.ble.getLittleEndianUInt32At
 import inc.combustion.framework.ble.getLittleEndianUShortAt
+import inc.combustion.framework.service.DebugSettings
 
 /**
  * Baseclass for UART response messages
@@ -108,24 +111,15 @@ internal open class NodeResponse(
             }
 
             when(messageType) {
-//                NodeMessageType.LOG -> {
-//                    return NodeLogResponse.fromRaw(
-//                        data,
-//                        success,
-//                        payloadLength
-//                    )
-//                }
-
-//                NodeMessageType.SET_ID -> {
-//                    return NodeSetIDResponse(success, payloadLength.toInt())
-//                }
-
-//                NodeMessageType.SET_COLOR -> {
-//                    return NodeSetColorResponse(
-//                        success,
-//                        payloadLength
-//                    )
-//                }
+                NodeMessageType.LOG -> {
+                    return NodeReadLogsResponse.fromData(
+                        data,
+                        success,
+                        requestId,
+                        responseId,
+                        payloadLength
+                    )
+                }
 
                 NodeMessageType.SESSION_INFO -> {
                     return NodeReadSessionInfoResponse.fromData(
@@ -176,6 +170,19 @@ internal open class NodeResponse(
                     )
                 }
 
+// TODO: The messages types below are not currently implemented
+
+//                NodeMessageType.SET_ID -> {
+//                    return NodeSetIDResponse(success, payloadLength.toInt())
+//                }
+
+//                NodeMessageType.SET_COLOR -> {
+//                    return NodeSetColorResponse(
+//                        success,
+//                        payloadLength
+//                    )
+//                }
+
 //                NodeMessageType.READ_OVER_TEMPERATURE -> {
 //                    return NodeReadOverTemperatureResponse(
 //                        data,
@@ -185,6 +192,9 @@ internal open class NodeResponse(
 //                }
 
                 else -> {
+                    if ( DebugSettings.DEBUG_LOG_MESSAGE_RESPONSES ) {
+                        Log.d(LOG_TAG, "NodeResponse: responseFromData: Unknown message type: $messageType")
+                    }
                     return null
                 }
             }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -132,7 +132,8 @@ internal open class NodeResponse(
                 }
 
                 NodeMessageType.SET_PREDICTION -> {
-                    return NodeSetPredictionResponse(
+                    return NodeSetPredictionResponse.fromData(
+                        data,
                         success,
                         requestId,
                         responseId,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetPredictionResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetPredictionResponse.kt
@@ -28,7 +28,10 @@
 
 package inc.combustion.framework.ble.uart.meatnet
 
+import inc.combustion.framework.ble.getLittleEndianUInt32At
+
 internal class NodeSetPredictionResponse (
+    val serialNumber: String,
     success: Boolean,
     requestId: UInt,
     responseId: UInt,
@@ -36,6 +39,30 @@ internal class NodeSetPredictionResponse (
 ) : NodeResponse(success, requestId, responseId, payloadLength) {
 
     companion object {
-        const val PAYLOAD_LENGTH: UInt = 0u
+        // payload is 4 bytes = serial number (4 bytes)
+        const val PAYLOAD_LENGTH: UByte = 4u
+
+        fun fromData(
+            payload: UByteArray,
+            success: Boolean,
+            requestId: UInt,
+            responseId: UInt,
+            payloadLength: UByte
+        ) : NodeSetPredictionResponse? {
+
+            if (payloadLength < PAYLOAD_LENGTH) {
+                return null
+            }
+
+            val serial = payload.getLittleEndianUInt32At(HEADER_SIZE.toInt()).toString(radix = 16).uppercase()
+
+            return NodeSetPredictionResponse(
+                serial,
+                success,
+                requestId,
+                responseId,
+                payloadLength
+            )
+        }
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeUARTMessage.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeUARTMessage.kt
@@ -27,6 +27,10 @@
  */
 package inc.combustion.framework.ble.uart.meatnet
 
+import android.util.Log
+import inc.combustion.framework.LOG_TAG
+import inc.combustion.framework.service.DebugSettings
+
 /**
  * Representation of Combustion BLE Node UART request. This top-level representation
  * is useful for decoding multiple UART messages from a single notification that can
@@ -60,6 +64,12 @@ internal open class NodeUARTMessage {
                     }
                     else {
                         // Found invalid response, break out of while loop
+                        if (DebugSettings.DEBUG_LOG_MESSAGE_REQUESTS || DebugSettings.DEBUG_LOG_MESSAGE_RESPONSES) {
+                            Log.d(
+                                LOG_TAG,
+                                "Node UART: Found invalid request or response, breaking out of while loop"
+                            )
+                        }
                         break
                     }
                 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/DataClasses.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/DataClasses.kt
@@ -40,7 +40,9 @@ internal data class RecordRange(val minSeq: UInt, val maxSeq: UInt) {
         val NULL_RECORD_RANGE = RecordRange(0u, 0u)
     }
 
-    val size: UInt get() { return maxSeq - minSeq + 1u }
+    val size: UInt get() {
+        return if(minSeq == maxSeq) 0u else maxSeq - minSeq + 1u
+    }
 }
 
 /**

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -86,7 +86,7 @@ internal class LogManager {
                             Log.d(LOG_TAG, "Probe Status Flow Complete")
                         }
                         .catch {
-                            Log.i(LOG_TAG, "Probde Status Flow Catch: $it")
+                            Log.i(LOG_TAG, "Probe Status Flow Catch: $it")
                         }
                         .collect { deviceStatus ->
                             when(probeManager.uploadState) {
@@ -252,7 +252,7 @@ internal class LogManager {
         // update the probe's upload state with the progress.
         probeManager.uploadState = progress.toProbeUploadState()
 
-        Log.i(LOG_TAG, "Requesting Logs: ${range.minSeq} to ${range.maxSeq} (${log.currentSessionId})")
+        Log.i(LOG_TAG, "Requesting Logs[$serialNumber]: ${range.minSeq} to ${range.maxSeq} (${log.currentSessionId})")
 
         // send the request to the device to start the upload
         probeManager.sendLogRequest(range.minSeq, range.maxSeq)
@@ -352,7 +352,7 @@ internal class LogManager {
         // update the legacyProbeManager's upload state with the progress.
         probeManager.uploadState = progress.toProbeUploadState()
 
-        Log.i(LOG_TAG, "Requesting Logs for Backfill: ${range.minSeq} to ${range.maxSeq} (${log.currentSessionId})")
+        Log.i(LOG_TAG, "Requesting Logs for Backfill[${probeManager.serialNumber}]: ${range.minSeq} to ${range.maxSeq} (${log.currentSessionId})")
 
         // send the request to the device to start the upload
         probeManager.sendLogRequest(range.minSeq, range.maxSeq)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -252,7 +252,7 @@ internal class LogManager {
         // update the probe's upload state with the progress.
         probeManager.uploadState = progress.toProbeUploadState()
 
-        Log.e("MATT", "Request Logs From Device: $progress. State: ${probeManager.uploadState}")
+        Log.i(LOG_TAG, "Requesting Logs: ${range.minSeq} to ${range.maxSeq} (${log.currentSessionId})")
 
         // send the request to the device to start the upload
         probeManager.sendLogRequest(range.minSeq, range.maxSeq)
@@ -305,9 +305,6 @@ internal class LogManager {
                     // syncing state, then exit out of this flow.
                     val sessionId = log.currentSessionId
                     probeManager.probeStatusFlow
-                        .onCompletion {
-                            Log.d(LOG_TAG, "Log Flow: Device Status Flow Complete")
-                        }
                         .catch {
                             Log.w(LOG_TAG, "Log Flow: Device Status Flow Catch: $it")
                         }
@@ -354,6 +351,8 @@ internal class LogManager {
 
         // update the legacyProbeManager's upload state with the progress.
         probeManager.uploadState = progress.toProbeUploadState()
+
+        Log.i(LOG_TAG, "Requesting Logs for Backfill: ${range.minSeq} to ${range.maxSeq} (${log.currentSessionId})")
 
         // send the request to the device to start the upload
         probeManager.sendLogRequest(range.minSeq, range.maxSeq)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
@@ -60,6 +60,7 @@ internal class ProbeTemperatureLog(private val serialNumber: String) {
     val currentSessionSamplePeriod: UInt get() = sessions.lastOrNull()?.samplePeriod ?: 0u
     val currentSessionStartTime: Date? get() = sessions.lastOrNull()?.startTime
     val logStartTime: Date? get() = sessions.firstOrNull()?.startTime
+    val droppedRecords: List<UInt>? get() = sessions.firstOrNull()?.droppedRecords
 
     val dataPointCount: Int
         get() {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/Session.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/Session.kt
@@ -67,7 +67,6 @@ internal class Session(
     private var logResponseDropCount = 0u
     private var deviceStatusDropCount = 0u
     private var staleLogRequestCount = STALE_LOG_REQUEST_PACKET_COUNT
-    private val droppedRecords = mutableListOf<UInt>()
     private val minSequenceNumber: UInt get() = if(isEmpty) 0u else _logs.firstKey()
     private val maxSequenceNumber: UInt get() = if(isEmpty) 0u else _logs.lastKey()
 
@@ -75,6 +74,7 @@ internal class Session(
     val samplePeriod = sessionInfo.samplePeriod
     val isEmpty get() = _logs.isEmpty()
     val startTime: Date
+    val droppedRecords = mutableListOf<UInt>()
 
     val maxSequentialSequenceNumber: UInt get() {
         val iterator = _logs.keys.sorted().iterator()
@@ -240,7 +240,7 @@ internal class Session(
         // check to see if we received duplicate data
         else if(probeStatus.maxSequenceNumber < nextExpectedDeviceStatus) {
             if(_logs.containsKey(probeStatus.maxSequenceNumber)) {
-                Log.w(LOG_TAG,
+                Log.d(LOG_TAG,
                     "Dropping duplicate device status: " +
                             "$serialNumber.${probeStatus.maxSequenceNumber} " +
                             "($nextExpectedDeviceStatus)(${probeStatus.maxSequenceNumber})")

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DebugSettings.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DebugSettings.kt
@@ -36,5 +36,7 @@ class DebugSettings {
         var DEBUG_LOG_CONNECTION_STATE = false
         var DEBUG_LOG_BLE_OPERATIONS = false
         var DEBUG_LOG_SERVICE_LIFECYCLE = false
+        var DEBUG_LOG_MESSAGE_REQUESTS = false
+        var DEBUG_LOG_MESSAGE_RESPONSES = false
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceConnectionState.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceConnectionState.kt
@@ -59,5 +59,22 @@ enum class DeviceConnectionState {
      * Device is currently disconnected.  Have not yet received an advertising packet
      * or determined that the device is out of range.
      */
-    DISCONNECTED
+    DISCONNECTED,
+    /**
+     * Connected to a repeater device, but not able to find a route to the destination endpoint.
+     */
+    NO_ROUTE;
+
+    override fun toString(): String {
+        return when(this) {
+            OUT_OF_RANGE -> "Out of Range"
+            ADVERTISING_CONNECTABLE -> "Connectable"
+            ADVERTISING_NOT_CONNECTABLE -> "Not Connectable"
+            CONNECTING -> "Connecting"
+            CONNECTED -> "Connected"
+            DISCONNECTING -> "Disconnecting"
+            DISCONNECTED -> "Disconnected"
+            NO_ROUTE -> "No Route"
+        }
+    }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
@@ -101,7 +101,8 @@ data class Probe(
     val hopCount: UInt? = null,
     val statusNotificationsStale: Boolean = false,
     val overheatingSensors: List<Int> = listOf(),
-    val recordsDownloaded: Int = 0
+    val recordsDownloaded: Int = 0,
+    val preferredLink: String = ""
 ) {
     val serialNumber = baseDevice.serialNumber
     val mac = baseDevice.mac


### PR DESCRIPTION
- MeatNet log transfer messages.
- Add in No Route connection state.
- Add in ping for checking when there isn't a route through the network.
- Arbitrate connection state, fw ver, hw ver, sku/lot.
- Fix issues when reading fw ver, hw rev, sku/lot from repeaters.

Not required, but should probably use the corresponding prod app branch.