### PR TITLE
DROID-205: Address Crashlytics

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -361,7 +361,6 @@ internal class ProbeManager(
         val networkIsOnlyAdvertising =
             (state == DeviceConnectionState.ADVERTISING_CONNECTABLE || state == DeviceConnectionState.ADVERTISING_NOT_CONNECTABLE)
 
-        Log.e("MATT", "Advertsing: $state")
         if(networkIsOnlyAdvertising) {
             if(arbitrator.shouldUpdateDataFromAdvertisingPacket(device, advertisement)) {
                 updateDataFromAdvertisement(advertisement)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
@@ -33,6 +33,7 @@ import android.app.NotificationManager
 import android.bluetooth.BluetoothManager
 import android.content.*
 import android.os.Binder
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import androidx.lifecycle.LifecycleService
@@ -75,7 +76,11 @@ class CombustionService : LifecycleService() {
                 this.dfuNotificationTarget = dfuNotificationTarget
                 notificationId = ThreadLocalRandom.current().asKotlinRandom().nextInt()
                 Intent(context, CombustionService::class.java).also { intent ->
-                    context.startService(intent)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        context.startForegroundService(intent)
+                    } else {
+                        context.startService(intent)
+                    }
                 }
                 serviceIsStopping.set(false)
             }


### PR DESCRIPTION
- Use proper API to start service when app is in the background on newer versions of Android.