### PR TITLE
DROID-222: Handle Null Service Notification

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
@@ -77,7 +77,11 @@ class CombustionService : LifecycleService() {
                 notificationId = ThreadLocalRandom.current().asKotlinRandom().nextInt()
                 Intent(context, CombustionService::class.java).also { intent ->
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        context.startForegroundService(intent)
+                        serviceNotification?.let {
+                            context.startForegroundService(intent)
+                        } ?: run {
+                            context.startService(intent)
+                        }
                     } else {
                         context.startService(intent)
                     }


### PR DESCRIPTION
- Bug generated an ANR -- since null is passed in for the notification, we can't start the service as foreground.

Can test using the example app and using the boolean flag in `MainActivity.kt` that disables foreground service.