### PR TITLE
DROID-235: New Sessions are not being added on probe reconnection through a Node/Repeater

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.0" />
+  </component>
+</project>

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -501,8 +501,14 @@ internal class ProbeManager(
                 arbitrator.directLinkDiscoverTimestamp = null
             }
 
-            if(device == logTransferLink) {
-                finishLogTransfer()
+            if(connectionState != DeviceConnectionState.CONNECTED) {
+                Log.d(LOG_TAG, "PM($serialNumber): ${device.productType}[${device.id}] No longer connected!  Clearing session info!")
+
+                sessionInfo = null
+
+                if(uploadState != ProbeUploadState.Unavailable) {
+                    finishLogTransfer()
+                }
             }
 
             // remove this item from the list of firmware details for the network

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
@@ -75,6 +75,9 @@ internal class ProbeTemperatureLog(private val serialNumber: String) {
         var minSeq = 0u
         var maxSeq = 0u
 
+        if(DebugSettings.DEBUG_LOG_SESSION_STATUS) {
+            Log.d(LOG_TAG, "Session list size: ${sessions.size}, IDs: ${sessions.map { it.id }}")
+        }
         // handle initial condition
         if(sessions.isEmpty()) {
             startNewSession(sessionInfo, deviceMaxSequence)


### PR DESCRIPTION
- added new check of connectionState in handleConenctionState to reset sessionInfo when not DeviceConnectionState.CONNECTED

Issue was more prevalent if you initially take a probe from a booster, allow it connect and become repeated through the booster, place the probe back in the booster, allow disconnect of booster to complete, then finally remove the probe from the booster and allow it become repeated through the booster again. The new session information would not get updated for that probe so it would use the older sequence min/max and also session id value. 