### PR TITLE
DROID-117: Add ability to only have one DFU running at a time

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/dfu/DfuState.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/dfu/DfuState.kt
@@ -44,6 +44,7 @@ sealed class DfuState {
             OUT_OF_RANGE,
             CONNECTING,
             READING_DEVICE_INFORMATION,
+            BLOCKED,
         }
         override fun copy(device: Device): DfuState = copy(device = device, status = status)
     }


### PR DESCRIPTION
- updated DfuBleDevice to have a enabled/disabled state which is reflected via DfuState
- update DfuManager to have a attribute that reflects if a DFU has been started
- added completion callback that is called when a DFU ends with Success, Error, or Aborted; All other devices get re-enabled