### PR TITLE
DROID-234, DROID-192 

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -66,6 +66,11 @@ internal class DataLinkArbitrator(
             return if(probeBleDevice?.isConnected == true) probeBleDevice else null
         }
 
+    val connectedNodeLinks: List<RepeatedProbeBleDevice>
+        get() {
+            return repeatedProbeBleDevices.filter { it.isConnected }
+        }
+
     val preferredMeatNetLink: ProbeBleDeviceBase?
         get() {
             // If meatnet is not enabled, then return the probe connection

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
@@ -121,22 +121,22 @@ internal class ProbeBleDevice (
     override fun disconnect() = uart.disconnect()
 
     override fun sendSessionInformationRequest(callback: ((Boolean, Any?) -> Unit)?)  {
-        sessionInfoHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
+        sessionInfoHandler.wait(uart.owner, PROBE_MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SessionInfoRequest())
     }
 
     override fun sendSetProbeColor(color: ProbeColor, callback: ((Boolean, Any?) -> Unit)?) {
-        setColorHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
+        setColorHandler.wait(uart.owner, PROBE_MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SetColorRequest(color))
     }
 
     override fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)?) {
-        setIdHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
+        setIdHandler.wait(uart.owner, PROBE_MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SetIDRequest(id))
     }
 
     override fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
-        setPredictionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
+        setPredictionHandler.wait(uart.owner, PROBE_MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SetPredictionRequest(setPointTemperatureC, mode))
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
@@ -135,7 +135,7 @@ internal class ProbeBleDevice (
         sendUartRequest(SetIDRequest(id))
     }
 
-    override fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, callback: ((Boolean, Any?) -> Unit)?) {
+    override fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
         setPredictionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SetPredictionRequest(setPointTemperatureC, mode))
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
@@ -121,22 +121,22 @@ internal class ProbeBleDevice (
     override fun disconnect() = uart.disconnect()
 
     override fun sendSessionInformationRequest(callback: ((Boolean, Any?) -> Unit)?)  {
-        sessionInfoHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, callback)
+        sessionInfoHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SessionInfoRequest())
     }
 
     override fun sendSetProbeColor(color: ProbeColor, callback: ((Boolean, Any?) -> Unit)?) {
-        setColorHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, callback)
+        setColorHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SetColorRequest(color))
     }
 
     override fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)?) {
-        setIdHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, callback)
+        setIdHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SetIDRequest(id))
     }
 
     override fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, callback: ((Boolean, Any?) -> Unit)?) {
-        setPredictionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, callback)
+        setPredictionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(SetPredictionRequest(setPointTemperatureC, mode))
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
@@ -112,6 +112,6 @@ internal abstract class ProbeBleDeviceBase() {
     abstract fun sendSessionInformationRequest(callback: ((Boolean, Any?) -> Unit)? = null)
     abstract fun sendSetProbeColor(color: ProbeColor, callback: ((Boolean, Any?) -> Unit)? = null)
     abstract fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)? = null)
-    abstract fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, callback: ((Boolean, Any?) -> Unit)? = null)
+    abstract fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)? = null)
     abstract fun sendLogRequest(minSequence: UInt, maxSequence: UInt, callback: (suspend (LogResponse) -> Unit)? = null)
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
@@ -28,21 +28,17 @@
 package inc.combustion.framework.ble.device
 
 import inc.combustion.framework.ble.ProbeStatus
-import inc.combustion.framework.ble.scanning.BaseAdvertisingData
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.ble.uart.LogResponse
 import inc.combustion.framework.service.*
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import java.util.concurrent.atomic.AtomicBoolean
 
 typealias LinkID = String
 
 internal abstract class ProbeBleDeviceBase() {
 
     companion object {
-        const val MESSAGE_RESPONSE_TIMEOUT_MS = 5000L
+        const val PROBE_MESSAGE_RESPONSE_TIMEOUT_MS = 5000L
+        const val MEATNET_MESSAGE_RESPONSE_TIMEOUT_MS = 30000L
 
         fun makeLinkId(advertisement: CombustionAdvertisingData?): LinkID {
             return "${advertisement?.id}_${advertisement?.probeSerialNumber}"

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
@@ -148,7 +148,7 @@ internal class RepeatedProbeBleDevice (
     override fun disconnect() = uart.disconnect()
 
     override fun sendSessionInformationRequest(callback: ((Boolean, Any?) -> Unit)?)  {
-        sessionInfoHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
+        sessionInfoHandler.wait(uart.owner, MEATNET_MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
         sendUartRequest(NodeReadSessionInfoRequest(probeSerialNumber))
     }
 
@@ -164,7 +164,7 @@ internal class RepeatedProbeBleDevice (
 
     override fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
         routeMonitor.activity()
-        setPredictionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS, reqId, callback)
+        setPredictionHandler.wait(uart.owner, MEATNET_MESSAGE_RESPONSE_TIMEOUT_MS, reqId, callback)
         sendUartRequest(NodeSetPredictionRequest(probeSerialNumber, setPointTemperatureC, mode, reqId))
     }
 
@@ -182,7 +182,7 @@ internal class RepeatedProbeBleDevice (
     suspend fun readProbeFirmwareVersion() {
         val channel = Channel<Unit>(0)
         routeMonitor.activity()
-        probeFirmwareRevisionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
+        probeFirmwareRevisionHandler.wait(uart.owner, MEATNET_MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
             if (success) {
                 val resp = response as NodeReadFirmwareRevisionResponse
                 _deviceInfoFirmwareVersion = FirmwareVersion.fromString(resp.firmwareRevision)
@@ -199,7 +199,7 @@ internal class RepeatedProbeBleDevice (
     suspend fun readProbeHardwareRevision() {
         val channel = Channel<Unit>(0)
         routeMonitor.activity()
-        probeHardwareRevisionHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
+        probeHardwareRevisionHandler.wait(uart.owner, MEATNET_MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
             if (success) {
                 val resp = response as NodeReadHardwareRevisionResponse
                 _deviceInfoHardwareRevision = resp.hardwareRevision
@@ -216,7 +216,7 @@ internal class RepeatedProbeBleDevice (
     suspend fun readProbeModelInformation() {
         val channel = Channel<Unit>(0)
         routeMonitor.activity()
-        probeModelInfoHandler.wait(uart.owner, MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
+        probeModelInfoHandler.wait(uart.owner, MEATNET_MESSAGE_RESPONSE_TIMEOUT_MS) { success, response ->
             if (success) {
                 val resp = response as NodeReadModelInfoResponse
                 _deviceInfoModelInformation = resp.modelInfo
@@ -426,7 +426,7 @@ internal class RepeatedProbeBleDevice (
     companion object {
         const val PING_RATE_MS = 1000L
         const val PING_SETTLING_MS = 10000L
-        const val IDLE_LINK_TIMEOUT = MESSAGE_RESPONSE_TIMEOUT_MS + 3000L
+        const val IDLE_LINK_TIMEOUT = PROBE_MESSAGE_RESPONSE_TIMEOUT_MS + 3000L
         const val PING_TIMEOUT_COUNT = 3
 
         const val INFO_LOG_MEATNET_TRACE = true

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
@@ -259,6 +259,7 @@ internal class SimulatedProbeBleDevice(
     override fun sendSetPrediction(
         setPointTemperatureC: Double,
         mode: ProbePredictionMode,
+        reqId: UInt?,
         callback: ((Boolean, Any?) -> Unit)?
     ) {
         callback?.let { it(true, null) }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
@@ -53,18 +53,28 @@ internal open class UartBleDevice(
     class MessageCompletionHandler {
         private val waiting = AtomicBoolean(false)
         private var completionCallback: ((Boolean, Any?) -> Unit)? = null
+        private var requestId: UInt? = null
         private var job: Job? = null
 
-        fun handled(result: Boolean, data: Any?) {
+        fun handled(result: Boolean, data: Any?, reqId: UInt? = null) {
+            // if we are waiting for a specific request id
+            requestId?.let {
+                // and we weren't called with the request id we are looking for
+                if(it != reqId) {
+                    // then return
+                    return
+                }
+            }
+
             job?.cancel()
             waiting.set(false)
             completionCallback?.let {
                 it(result, data)
             }
-            completionCallback = null
+            cleanup()
         }
 
-        fun wait(owner: LifecycleOwner, duration: Long, callback: ((Boolean, Any?) -> Unit)?) {
+        fun wait(owner: LifecycleOwner, duration: Long, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)?) {
             completionCallback?.let {
                 callback?.let { it(false, null) }
                 return
@@ -77,14 +87,20 @@ internal open class UartBleDevice(
 
             waiting.set(true)
             completionCallback = callback
+            requestId = reqId
 
             job = owner.lifecycleScope.launch {
                 delay(duration)
                 if(waiting.getAndSet(false)) {
                     callback?.let { it(false, null) }
-                    completionCallback = null
+                    cleanup()
                 }
             }
+        }
+
+        private fun cleanup() {
+            completionCallback = null
+            requestId = null
         }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeHeartbeatRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeHeartbeatRequest.kt
@@ -42,7 +42,7 @@ internal class NodeHeartbeatRequest (
     val connectionDetails: List<ConnectionDetail>,
     requestId: UInt,
     payloadLength: UByte
-) : NodeRequest(requestId, payloadLength) {
+) : NodeRequest(requestId, payloadLength, NodeMessageType.HEARTBEAT) {
     class ConnectionDetail(
         val present: Boolean,
         val serialNumber: String = "",
@@ -156,7 +156,7 @@ internal class NodeHeartbeatRequest (
 
     override fun toString(): String {
         val inboundString = if (inbound) "ib" else "ob"
-        return "$macAddress ($serialNumber | $productType): $inboundString $hopCount; ${connectionDetails.joinToString()}"
+        return "${super.toString()} $inboundString $hopCount; ${connectionDetails.joinToString()}"
     }
 }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
@@ -38,7 +38,7 @@ internal class NodeProbeStatusRequest(
     val serialNumber: String,
     val hopCount: HopCount,
     val probeStatus: ProbeStatus
-) : NodeRequest(requestId, payloadLength) {
+) : NodeRequest(requestId, payloadLength, NodeMessageType.PROBE_STATUS) {
 
     companion object {
         const val PAYLOAD_LENGTH: UByte = 35u

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadFirmwareRevisionRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadFirmwareRevisionRequest.kt
@@ -31,12 +31,13 @@
 
 
 internal class NodeReadFirmwareRevisionRequest(
-    serialNumber: String
+    serialNumber: String,
+    requestId: UInt? = null
 ) : NodeRequest(
     populatePayload(serialNumber),
-    NodeMessageType.PROBE_FIRMWARE_REVISION
+    NodeMessageType.PROBE_FIRMWARE_REVISION,
+    requestId
 ) {
-
     companion object {
         const val PAYLOAD_LENGTH: UByte = 4u
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadFirmwareRevisionResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadFirmwareRevisionResponse.kt
@@ -41,7 +41,8 @@ internal class NodeReadFirmwareRevisionResponse (
     success,
     requestId,
     responseId,
-    payloadLength
+    payloadLength,
+    NodeMessageType.PROBE_FIRMWARE_REVISION
 ) {
     companion object {
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadHardwareRevisionRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadHardwareRevisionRequest.kt
@@ -32,11 +32,12 @@ import inc.combustion.framework.ble.putLittleEndianUInt32At
 
 internal class NodeReadHardwareRevisionRequest (
     serialNumber: String,
+    requestId: UInt? = null
 ) : NodeRequest(
     populatePayload(serialNumber),
-    NodeMessageType.PROBE_HARDWARE_REVISION
+    NodeMessageType.PROBE_HARDWARE_REVISION,
+    requestId
 ) {
-
     companion object {
         const val PAYLOAD_LENGTH: UByte = 4u
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadHardwareRevisionResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadHardwareRevisionResponse.kt
@@ -41,7 +41,8 @@ internal class NodeReadHardwareRevisionResponse (
     success,
     requestId,
     response,
-    payloadLength
+    payloadLength,
+    NodeMessageType.PROBE_HARDWARE_REVISION
 ) {
     companion object {
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsRequest.kt
@@ -34,13 +34,15 @@ internal class NodeReadLogsRequest(
     serialNumber: String,
     minSequence: UInt,
     maxSequence: UInt,
+    requestId: UInt? = null
 ) : NodeRequest(
     populatePayload(
         serialNumber,
         minSequence,
         maxSequence
     ),
-    NodeMessageType.LOG
+    NodeMessageType.LOG,
+    requestId
 ) {
     companion object {
         /// payload length 12 = serial number (4 bytes) + min sequence (4 bytes) + max sequence (4 bytes)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsResponse.kt
@@ -29,6 +29,7 @@
 package inc.combustion.framework.ble.uart.meatnet
 
 import inc.combustion.framework.ble.getLittleEndianUInt32At
+import inc.combustion.framework.ble.uart.MessageType
 import inc.combustion.framework.service.PredictionLog
 import inc.combustion.framework.service.ProbeTemperatures
 
@@ -45,7 +46,8 @@ internal class NodeReadLogsResponse(
     success,
     requestId,
     responseId,
-    payLoadLength
+    payLoadLength,
+    NodeMessageType.LOG
 ) {
     companion object {
         private const val MIN_PAYLOAD_LENGTH: UByte = 28u

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoRequest.kt
@@ -32,9 +32,11 @@ import inc.combustion.framework.ble.putLittleEndianUInt32At
 
 internal class NodeReadModelInfoRequest (
     serialNumber: String,
+    requestId: UInt? = null
 ) : NodeRequest(
     populatePayload(serialNumber),
-    NodeMessageType.PROBE_MODEL_INFORMATION
+    NodeMessageType.PROBE_MODEL_INFORMATION,
+    requestId
 ) {
     companion object {
         const val PAYLOAD_LENGTH: UByte = 4u

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadModelInfoResponse.kt
@@ -42,11 +42,14 @@ internal class NodeReadModelInfoResponse (
     success,
     requestId,
     responseId,
-    payloadLength
+    payloadLength,
+    NodeMessageType.PROBE_MODEL_INFORMATION
 ) {
+    override fun toString(): String {
+        return "${super.toString()} $serialNumber ${modelInfo.productType} ${modelInfo.sku} ${modelInfo.manufacturingLot}"
+    }
 
     companion object {
-
         // payload is 54 bytes = serial number (4 bytes) + model info (50 bytes)
         const val PAYLOAD_LENGTH: UByte = 54u
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoRequest.kt
@@ -32,9 +32,11 @@ import inc.combustion.framework.ble.putLittleEndianUInt32At
 
 internal class NodeReadSessionInfoRequest (
     serialNumber: String,
+    requestId: UInt? = null
 ) : NodeRequest(
     populatePayload(serialNumber),
-    NodeMessageType.SESSION_INFO
+    NodeMessageType.SESSION_INFO,
+    requestId
 ) {
 
         companion object {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoResponse.kt
@@ -43,7 +43,8 @@ internal class NodeReadSessionInfoResponse (
     success,
     requestId,
     responseId,
-    payloadLength
+    payloadLength,
+    NodeMessageType.SESSION_INFO
 ) {
     companion object {
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
@@ -34,12 +34,20 @@ import inc.combustion.framework.ble.getCRC16CCITT
 import inc.combustion.framework.ble.getLittleEndianUInt32At
 import inc.combustion.framework.ble.putLittleEndianUInt32At
 import inc.combustion.framework.ble.putLittleEndianUShortAt
-import inc.combustion.framework.service.DebugSettings
+import inc.combustion.framework.ble.uart.MessageType
 
 /**
  * Baseclass for UART request messages
  */
-internal open class NodeRequest() : NodeUARTMessage() {
+internal open class NodeRequest(
+    messageId: NodeMessageType
+) : NodeUARTMessage(
+    messageId
+) {
+    override fun toString(): String {
+        return "REQ  $messageId (REQID: ${String.format("%08x", requestId.toInt())})"
+    }
+
     companion object {
         const val HEADER_SIZE: UByte = 10u
 
@@ -92,7 +100,6 @@ internal open class NodeRequest() : NodeUARTMessage() {
             }
 
             return when(messageType) {
-
                 NodeMessageType.PROBE_STATUS -> {
                     NodeProbeStatusRequest.fromRaw(
                         data,
@@ -100,22 +107,14 @@ internal open class NodeRequest() : NodeUARTMessage() {
                         payloadLength
                     )
                 }
-
                 NodeMessageType.HEARTBEAT -> {
-                    return NodeHeartbeatRequest.fromRaw(
+                    NodeHeartbeatRequest.fromRaw(
                         data,
                         requestId,
                         payloadLength
                     )
                 }
-
-                else -> {
-                    if ( DebugSettings.DEBUG_LOG_MESSAGE_REQUESTS ) {
-                        Log.d(LOG_TAG, "NodeRequest: Unknown message type: $messageType")
-                    }
-
-                    null
-                }
+                else -> null
             }
         }
 
@@ -137,23 +136,28 @@ internal open class NodeRequest() : NodeUARTMessage() {
      *
      * @param outgoingPayload data containing outgoing payload
      * @param type type of request message
+     * @param requestId optional request id
      */
     constructor(
         outgoingPayload: UByteArray,
-        type: NodeMessageType
-    ) : this() {
+        messageType: NodeMessageType,
+        requestId: UInt? = null
+    ) : this(
+        messageType
+    ) {
         // Sync Bytes { 0xCA, 0xFE }
-        this.data += 0xCAu
-        this.data += 0xFEu
+        data += 0xCAu
+        data += 0xFEu
 
         // Calculate CRC over Message Type, request ID, payload length, payload
         var crcData = UByteArray(0)
 
         // Message type
-        crcData += type.value
+        crcData += messageType.value
 
         // Request ID
-        this.requestId = (0u..UInt.MAX_VALUE).random()
+        this.requestId = requestId ?: (0u..UInt.MAX_VALUE).random()
+
         crcData += UByteArray(4)
         crcData.putLittleEndianUInt32At(1, this.requestId)
 
@@ -173,7 +177,6 @@ internal open class NodeRequest() : NodeUARTMessage() {
         this.payloadLength = outgoingPayload.size.toUByte()
     }
 
-
     /**
      * Constructor for an incoming Request object (from MeatNet).
      *
@@ -182,12 +185,14 @@ internal open class NodeRequest() : NodeUARTMessage() {
      */
     constructor(
         requestId: UInt,
-        payloadLength: UByte
-    ) : this() {
+        payloadLength: UByte,
+        messageId: NodeMessageType
+    ) : this(
+        messageId
+    ) {
         this.requestId = requestId
         this.payloadLength = payloadLength
     }
-
 
     /**
      * Calculates the CRC16 over the message type, payload length, and payload and inserts the

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -41,8 +41,14 @@ internal open class NodeResponse(
     val success: Boolean,
     val requestId: UInt,
     val responseId: UInt,
-    val payloadLength: UByte
-) : NodeUARTMessage() {
+    val payloadLength: UByte,
+    messageId: NodeMessageType
+) : NodeUARTMessage(
+    messageId
+) {
+    override fun toString(): String {
+        return "RESP $messageId (REQID: ${String.format("%08x",requestId.toInt())} RSPID: ${String.format("%08x",responseId.toInt())})"
+    }
 
     companion object {
         const val HEADER_SIZE : UByte = 15u
@@ -57,7 +63,6 @@ internal open class NodeResponse(
          * @return Instant of request if found or null if one could not be parsed from the data
          */
         fun responseFromData(data : UByteArray) : NodeResponse? {
-
             // Sync bytes
             val syncBytes = data.slice(0..1)
             val expectedSync = listOf<UByte>(202u, 254u) // 0xCA, 0xFE
@@ -110,9 +115,9 @@ internal open class NodeResponse(
                 return null
             }
 
-            when(messageType) {
+            return when(messageType) {
                 NodeMessageType.LOG -> {
-                    return NodeReadLogsResponse.fromData(
+                    NodeReadLogsResponse.fromData(
                         data,
                         success,
                         requestId,
@@ -120,9 +125,8 @@ internal open class NodeResponse(
                         payloadLength
                     )
                 }
-
                 NodeMessageType.SESSION_INFO -> {
-                    return NodeReadSessionInfoResponse.fromData(
+                    NodeReadSessionInfoResponse.fromData(
                         data,
                         success,
                         requestId,
@@ -130,9 +134,8 @@ internal open class NodeResponse(
                         payloadLength
                     )
                 }
-
                 NodeMessageType.SET_PREDICTION -> {
-                    return NodeSetPredictionResponse.fromData(
+                    NodeSetPredictionResponse.fromData(
                         data,
                         success,
                         requestId,
@@ -140,9 +143,8 @@ internal open class NodeResponse(
                         payloadLength
                     )
                 }
-
                 NodeMessageType.PROBE_FIRMWARE_REVISION -> {
-                    return NodeReadFirmwareRevisionResponse.fromData(
+                    NodeReadFirmwareRevisionResponse.fromData(
                         data,
                         success,
                         requestId,
@@ -150,9 +152,8 @@ internal open class NodeResponse(
                         payloadLength
                     )
                 }
-
                 NodeMessageType.PROBE_HARDWARE_REVISION -> {
-                    return NodeReadHardwareRevisionResponse.fromData(
+                    NodeReadHardwareRevisionResponse.fromData(
                         data,
                         success,
                         requestId,
@@ -160,9 +161,8 @@ internal open class NodeResponse(
                         payloadLength
                     )
                 }
-
                 NodeMessageType.PROBE_MODEL_INFORMATION -> {
-                    return NodeReadModelInfoResponse.fromData(
+                    NodeReadModelInfoResponse.fromData(
                         data,
                         success,
                         requestId,
@@ -170,36 +170,8 @@ internal open class NodeResponse(
                         payloadLength
                     )
                 }
-
-// TODO: The messages types below are not currently implemented
-
-//                NodeMessageType.SET_ID -> {
-//                    return NodeSetIDResponse(success, payloadLength.toInt())
-//                }
-
-//                NodeMessageType.SET_COLOR -> {
-//                    return NodeSetColorResponse(
-//                        success,
-//                        payloadLength
-//                    )
-//                }
-
-//                NodeMessageType.READ_OVER_TEMPERATURE -> {
-//                    return NodeReadOverTemperatureResponse(
-//                        data,
-//                        success,
-//                        payloadLength
-//                    )
-//                }
-
-                else -> {
-                    if ( DebugSettings.DEBUG_LOG_MESSAGE_RESPONSES ) {
-                        Log.d(LOG_TAG, "NodeResponse: responseFromData: Unknown message type: $messageType")
-                    }
-                    return null
-                }
+                else -> null
             }
         }
     }
-
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetPredictionRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetPredictionRequest.kt
@@ -32,12 +32,18 @@ import inc.combustion.framework.ble.putLittleEndianUInt32At
 import inc.combustion.framework.service.ProbePredictionMode
 
 internal class NodeSetPredictionRequest(
-    serialNumber: String,
-    setPointTemperatureC: Double,
-    mode: ProbePredictionMode
-
-) : NodeRequest(populatePayload(serialNumber, setPointTemperatureC, mode),
-                NodeMessageType.SET_PREDICTION) {
+    val serialNumber: String,
+    private val setPointTemperatureC: Double,
+    val mode: ProbePredictionMode,
+    requestId: UInt? = null
+) : NodeRequest(
+    populatePayload(serialNumber, setPointTemperatureC, mode),
+    NodeMessageType.SET_PREDICTION,
+    requestId
+) {
+    override fun toString(): String {
+        return "${super.toString()} $serialNumber $setPointTemperatureC $mode"
+    }
 
     companion object {
         const val PAYLOAD_LENGTH: UByte = 6u
@@ -68,5 +74,4 @@ internal class NodeSetPredictionRequest(
             return payload
         }
     }
-
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetPredictionResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetPredictionResponse.kt
@@ -28,19 +28,27 @@
 
 package inc.combustion.framework.ble.uart.meatnet
 
+import android.util.Log
 import inc.combustion.framework.ble.getLittleEndianUInt32At
 
 internal class NodeSetPredictionResponse (
-    val serialNumber: String,
     success: Boolean,
     requestId: UInt,
     responseId: UInt,
     payloadLength: UByte
-) : NodeResponse(success, requestId, responseId, payloadLength) {
+) : NodeResponse(
+    success,
+    requestId,
+    responseId,
+    payloadLength,
+    NodeMessageType.SET_PREDICTION
+) {
+    override fun toString(): String {
+        return "${super.toString()} $success"
+    }
 
     companion object {
-        // payload is 4 bytes = serial number (4 bytes)
-        const val PAYLOAD_LENGTH: UByte = 4u
+        const val PAYLOAD_LENGTH: UByte = 0u
 
         fun fromData(
             payload: UByteArray,
@@ -54,10 +62,7 @@ internal class NodeSetPredictionResponse (
                 return null
             }
 
-            val serial = payload.getLittleEndianUInt32At(HEADER_SIZE.toInt()).toString(radix = 16).uppercase()
-
             return NodeSetPredictionResponse(
-                serial,
                 success,
                 requestId,
                 responseId,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeUARTMessage.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeUARTMessage.kt
@@ -36,7 +36,9 @@ import inc.combustion.framework.service.DebugSettings
  * is useful for decoding multiple UART messages from a single notification that can
  * be both NodeRequest and NodeResponse types.
  */
-internal open class NodeUARTMessage {
+internal open class NodeUARTMessage(
+    val messageId: NodeMessageType
+) {
     companion object {
         /**
          * Returns an array of NodeUARTMessage objects (both responses and requests)
@@ -54,15 +56,12 @@ internal open class NodeUARTMessage {
                 NodeResponse.responseFromData(bytesToDecode)?.let {
                     messages.add(it)
                     numberBytesRead += (it.payloadLength + NodeResponse.HEADER_SIZE).toInt()
-
                 } ?: run {
-
                     // If NodeResponse parsing failed, try to decode a NodeRequest.
                     NodeRequest.requestFromData(bytesToDecode)?.let {
                         messages.add(it)
                         numberBytesRead += (it.payloadLength + NodeRequest.HEADER_SIZE).toInt()
                     } ?: run {
-
                         // drop data here, and return out what we have parsed so far
                         // Log.w(LOG_TAG, "MeatNet: Parsed invalid or unknown data! Dropping bytes $numberBytesRead to ${data.size}")
                         return messages

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DebugSettings.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DebugSettings.kt
@@ -38,6 +38,5 @@ class DebugSettings {
         var DEBUG_LOG_SERVICE_LIFECYCLE = false
         var DEBUG_LOG_MESSAGE_REQUESTS = false
         var DEBUG_LOG_MESSAGE_RESPONSES = false
-        var INFO_LOG_MEATNET_TRACE = true
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DebugSettings.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DebugSettings.kt
@@ -38,5 +38,6 @@ class DebugSettings {
         var DEBUG_LOG_SERVICE_LIFECYCLE = false
         var DEBUG_LOG_MESSAGE_REQUESTS = false
         var DEBUG_LOG_MESSAGE_RESPONSES = false
+        var INFO_LOG_MEATNET_TRACE = true
     }
 }


### PR DESCRIPTION
- Use worse-case 30s message timeout for MeatNet messages.
- Send Set Prediction Request to all nodes and handle the first response.
- Add message trace filter
- Add optional request id to message handler class.
- Add Node UART message tracing.
- Fix SetPredictionResponse handling.