### PR TITLE
DROID-238, DROID-241, DROID-242, DROID-243, DROID-236

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -141,6 +141,16 @@ internal class ProbeManager(
             }
         }
 
+    var logUploadPercent: UInt
+        get() {
+            return _probe.value.logUploadPercent
+        }
+        set(value) {
+            if(value != _probe.value.logUploadPercent) {
+                _probe.value = _probe.value.copy(logUploadPercent = value)
+            }
+        }
+
     val connectionState: DeviceConnectionState
         get() {
             // if this is a simulated probe, no need to arbitrate
@@ -731,6 +741,7 @@ internal class ProbeManager(
             return
         }
 
+        sessionInfoTimeout = false
         val info = any as SessionInformation
 
         // if the session information has changed, then we need to finish the previous log session.

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -94,11 +94,11 @@ internal class ProbeManager(
     val probeFlow = _probe.asStateFlow()
 
     // the flow that produces ProbeStatus updates from MeatNet
-    private val _probeStatusFlow = MutableSharedFlow<ProbeStatus>(
+    private val _normalModeProbeStatusFlow = MutableSharedFlow<ProbeStatus>(
         replay = 0, extraBufferCapacity = 10, BufferOverflow.DROP_OLDEST)
 
     // the flow that is consumed to get ProbeStatus updates from MeatNet
-    val probeStatusFlow = _probeStatusFlow.asSharedFlow()
+    val normalModeProbeStatusFlow = _normalModeProbeStatusFlow.asSharedFlow()
 
     // the flow that produces LogResponses from MeatNet
     private val _logResponseFlow = MutableSharedFlow<LogResponse>(
@@ -106,6 +106,10 @@ internal class ProbeManager(
 
     // tracks the link that is processing the most recent log transfer
     private var logTransferLink: ProbeBleDeviceBase? = null
+
+    // tracks if we've run into a message timeout condition getting
+    // session info
+    private var sessionInfoTimeout: Boolean = false
 
     // the flow that is consumed to get LogResponses from MeatNet
     val logResponseFlow = _logResponseFlow.asSharedFlow()
@@ -149,14 +153,28 @@ internal class ProbeManager(
                 return arbitrator.probeBleDevice?.connectionState ?: DeviceConnectionState.OUT_OF_RANGE
             }
 
+            // if the MeatNet preferred link is the direct link, then just use the direct link's state.
+            if(arbitrator.directLink == arbitrator.preferredMeatNetLink) {
+                arbitrator.directLink?.let {
+                    return it.connectionState
+                }
+            }
+
             // if all devices are out of range, then connection state is Out of Range
             if(arbitrator.meatNetIsOutOfRange) {
                 return DeviceConnectionState.OUT_OF_RANGE
             }
 
-            // else, if have a preferred meatnet link (connected with route), then use that connection state
-            arbitrator.preferredMeatNetLink?.let {
-                return it.connectionState
+            // else, if there is any device that is connected
+            arbitrator.getPreferredConnectionState(DeviceConnectionState.CONNECTED)?.let {
+                // and we have run into a session info message timeout condition, then we are
+                // in a NO_ROUTE scenario.
+                if(sessionInfoTimeout) {
+                    return DeviceConnectionState.NO_ROUTE
+                }
+
+                // otherwise, we are connected
+                return DeviceConnectionState.CONNECTED
             }
 
             // else, if there is any device that is connecting
@@ -293,8 +311,13 @@ internal class ProbeManager(
 
             // process simulated device status notifications
             simProbe.observeProbeStatusUpdates { status ->
-                updateDataFromProbeStatus(status)
-                _probeStatusFlow.emit(status)
+                if(status.mode == ProbeMode.NORMAL) {
+                    updateNormalMode(status)
+                    _normalModeProbeStatusFlow.emit(status)
+                }
+                else if(status.mode == ProbeMode.INSTANT_READ) {
+                    updateInstantRead(status)
+                }
             }
 
             // process simulated connection state changes
@@ -383,8 +406,9 @@ internal class ProbeManager(
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if(nodeLinks.isNotEmpty()) {
                     var handled = false
+                    val requestId = makeRequestId()
                     nodeLinks.forEach {
-                        it.sendSetPrediction(removalTemperatureC, mode, makeRequestId()) {status, _ ->
+                        it.sendSetPrediction(removalTemperatureC, mode, requestId) {status, _ ->
                             if(!handled) {
                                 handled = true
                                 completionHandler(status)
@@ -452,12 +476,22 @@ internal class ProbeManager(
     }
 
     private suspend fun handleProbeStatus(device: ProbeBleDeviceBase, status: ProbeStatus) {
-        if(arbitrator.shouldUpdateDataFromProbeStatus(device)) {
-            updateDataFromProbeStatus(status)
+        if(arbitrator.shouldUpdateDataFromProbeStatus(status, sessionInfo)) {
+            if(status.mode == ProbeMode.NORMAL) {
+                updateNormalMode(status)
 
-            // redundantly check for device information, if we don't have that data, then we
-            // want to keep requesting it until it makes it across the network.
-            fetchDeviceInfo(device)
+                _normalModeProbeStatusFlow.emit(status)
+
+                // redundantly check for device information
+                fetchDeviceInfo()
+            }
+            else if(status.mode == ProbeMode.INSTANT_READ) {
+                updateInstantRead(status)
+            }
+
+            updateLink()
+            updateBatteryIdColor(status.batteryStatus, status.id, status.color)
+            updateSequenceNumbers(status.minSequenceNumber, status.maxSequenceNumber)
         }
 
         // optimize MeatNet connection resources.  if we have a direct link to a probe we want to
@@ -470,8 +504,6 @@ internal class ProbeManager(
                 directLink.disconnect()
             }
         }
-
-        _probeStatusFlow.emit(status)
     }
 
     private fun handleAdvertisingPackets(device: ProbeBleDeviceBase, advertisement: CombustionAdvertisingData) {
@@ -502,7 +534,7 @@ internal class ProbeManager(
 
         if(isConnected) {
             Log.i(LOG_TAG, "PM($serialNumber): ${device.productType}[${device.id}] is connected.")
-            handleConnectedState(device)
+            fetchDeviceInfo()
         }
 
         if(isDisconnected) {
@@ -516,57 +548,18 @@ internal class ProbeManager(
                 arbitrator.directLinkDiscoverTimestamp = null
             }
 
-            if(connectionState != DeviceConnectionState.CONNECTED) {
-                Log.i(LOG_TAG, "PM($serialNumber): ${device.productType}[${device.id}] No longer connected!  Clearing session info!")
-
-                sessionInfo = null
-
-                if(uploadState != ProbeUploadState.Unavailable) {
-                    finishLogTransfer()
-                }
-            }
-
             // remove this item from the list of firmware details for the network
             dfuDisconnectedNodeCallback(device.id)
-        }
-
-        // if we no longer have a UART route to the probe, then null SessionInfo so that it can
-        // be requested/refreshed when a route is established.  We also no longer have a downstream
-        // link to the probe, so finish of the log transfer.
-        if(state == DeviceConnectionState.NO_ROUTE) {
-            if(arbitrator.hasNoUartRoute) {
-                Log.i(LOG_TAG, "PM($serialNumber): No UART route to probe.  Clearing session info.")
-
-                sessionInfo = null
-
-                if(uploadState != ProbeUploadState.Unavailable) {
-                    finishLogTransfer()
-                }
-            }
         }
 
         // use the arbitrated connection state, fw version, hw revision, model information
         _probe.value = _probe.value.copy(
             baseDevice = _probe.value.baseDevice.copy(
                 connectionState = connectionState,
-                fwVersion = fwVersion,
                 hwRevision = hwRevision,
                 modelInformation = modelInformation
-            ),
-            // event out current session info and the preferred link
-            sessionInfo = sessionInfo,
-            preferredLink = arbitrator.preferredMeatNetLink?.mac ?: ""
+            )
         )
-    }
-
-    private fun finishLogTransfer() {
-        logTransferCompleteCallback()
-
-        logTransferLink = null
-
-        uploadState = ProbeUploadState.Unavailable
-
-        Log.i(LOG_TAG, "PM($serialNumber): finished log transfer.")
     }
 
     private fun handleOutOfRange() {
@@ -586,89 +579,108 @@ internal class ProbeManager(
         }
     }
 
-    private fun handleConnectedState(device: ProbeBleDeviceBase) {
-        fetchDeviceInfo(device)
+    private fun fetchDeviceInfo() {
         fetchSessionInfo()
+        fetchFirmwareVersion()
+        fetchHardwareRevision()
+        fetchModelInformation()
     }
 
-    private fun fetchDeviceInfo(device: ProbeBleDeviceBase) {
-        fetchFirmwareVersion(device)
-        fetchSerialNumber(device)
-        fetchHardwareRevision(device)
-        fetchModelInformation(device)
-    }
+    private fun fetchFirmwareVersion() {
+        // if we don't know the probe's firmware version
+        if(_probe.value.fwVersion == null) {
 
-    private fun fetchFirmwareVersion(device: ProbeBleDeviceBase) {
-        var didReadDeviceInfo = false
-        owner.lifecycleScope.launch {
-            device.deviceInfoFirmwareVersion ?: run {
-                didReadDeviceInfo = true
-                when(device) {
-                    is ProbeBleDevice -> device.readFirmwareVersion()
-                    is RepeatedProbeBleDevice -> device.readProbeFirmwareVersion()
-                }
-            }
-        }.invokeOnCompletion {
-            if(didReadDeviceInfo) {
-                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(
-                    fwVersion = fwVersion,
-                ))
+            // if direct link, then get the probe version over that link
+            arbitrator.directLink?.readProbeFirmwareVersion {
 
-                device.deviceInfoFirmwareVersion?.let {
-                    dfuConnectedNodeCallback(FirmwareState.Node(
-                        id = device.id,
-                        type = device.productType,
-                        firmwareVersion = it
-                    ))
-                }
-            }
-        }
-    }
+                // update firmware version on completion of read
+                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(fwVersion = it))
+            } ?: run {
 
-    private fun fetchSerialNumber(device: ProbeBleDeviceBase) {
-        owner.lifecycleScope.launch {
-            device.deviceInfoSerialNumber ?: run {
-                when (device) {
-                    is ProbeBleDevice -> device.readSerialNumber()
+                // otherwise, use MeatNet is there is a connection
+                val nodeLinks = arbitrator.connectedNodeLinks
+                if(nodeLinks.isNotEmpty()) {
+                    var handled = false
+                    val requestId = makeRequestId()
+
+                    // for each MeatNet link, send the request
+                    nodeLinks.forEach {
+                        it.readProbeFirmwareVersion(requestId) {version ->
+
+                            // on first response from network, use the value
+                            if(!handled) {
+                                handled = true
+                                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(fwVersion = version))
+                            }
+                        }
+                    }
                 }
             }
         }
     }
 
-    private fun fetchHardwareRevision(device: ProbeBleDeviceBase) {
-        var didReadDeviceInfo = false
-        owner.lifecycleScope.launch {
-            device.deviceInfoHardwareRevision ?: run {
-                didReadDeviceInfo = true
-                when (device) {
-                    is ProbeBleDevice -> device.readHardwareRevision()
-                    is RepeatedProbeBleDevice -> device.readProbeHardwareRevision()
+    private fun fetchHardwareRevision() {
+        // if we don't know the probe's hardware revision
+        if(_probe.value.hwRevision == null) {
+
+            // if direct link, then get the probe revision over that link
+            arbitrator.directLink?.readProbeHardwareRevision {
+
+                // update firmware version on completion of read
+                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(hwRevision = it))
+            } ?: run {
+
+                // otherwise, use MeatNet is there is a connection
+                val nodeLinks = arbitrator.connectedNodeLinks
+                if(nodeLinks.isNotEmpty()) {
+                    var handled = false
+                    val requestId = makeRequestId()
+
+                    // for each MeatNet link, send the request
+                    nodeLinks.forEach {
+                        it.readProbeHardwareRevision(requestId) { revision ->
+
+                            // on first response from network, use the value
+                            if(!handled) {
+                                handled = true
+                                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(hwRevision = revision))
+                            }
+                        }
+                    }
                 }
-            }
-        }.invokeOnCompletion {
-            if(didReadDeviceInfo) {
-                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(
-                    hwRevision = hwRevision,
-                ))
             }
         }
     }
 
-    private fun fetchModelInformation(device: ProbeBleDeviceBase) {
-        var didReadDeviceInfo = false
-        owner.lifecycleScope.launch {
-            device.deviceInfoModelInformation ?: run {
-                didReadDeviceInfo = true
-                when (device) {
-                    is ProbeBleDevice -> device.readModelInformation()
-                    is RepeatedProbeBleDevice -> device.readProbeModelInformation()
+    private fun fetchModelInformation() {
+        // if we don't know the probe's model information
+        if(_probe.value.modelInformation == null) {
+
+            // if direct link, then get the probe model info over that link
+            arbitrator.directLink?.readProbeModelInformation {
+
+                // update firmware version on completion of read
+                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(modelInformation = it))
+            } ?: run {
+
+                // otherwise, use MeatNet is there is a connection
+                val nodeLinks = arbitrator.connectedNodeLinks
+                if(nodeLinks.isNotEmpty()) {
+                    var handled = false
+                    val requestId = makeRequestId()
+
+                    // for each MeatNet link, send the request
+                    nodeLinks.forEach {
+                        it.readProbeModelInformation(requestId) { info ->
+
+                            // on first response from network, use the value
+                            if(!handled) {
+                                handled = true
+                                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(modelInformation = info))
+                            }
+                        }
+                    }
                 }
-            }
-        }.invokeOnCompletion {
-            if(didReadDeviceInfo) {
-                _probe.value = _probe.value.copy(baseDevice = _probe.value.baseDevice.copy(
-                    modelInformation = modelInformation
-                ))
             }
         }
     }
@@ -678,21 +690,59 @@ internal class ProbeManager(
             if(sessionInfo == null) {
                 it.sendSessionInformationRequest { status, info ->
                     if(status && info is SessionInformation) {
-                        updateSessionInfo(info)
+                        sessionInfo = info
+                        _probe.value = _probe.value.copy(sessionInfo = info)
                     }
                 }
             }
         } ?: run {
-            arbitrator.preferredMeatNetLink?.let {
-                if(sessionInfo == null) {
-                    it.sendSessionInformationRequest { status, info ->
-                        if(status && info is SessionInformation) {
-                            updateSessionInfo(info)
+            // if direct link, then get the session info directly from the probe
+            arbitrator.directLink?.sendSessionInformationRequest(null, ::handleSessionInfo)
+            ?: run {
+                // otherwise, use MeatNet is there is a connection
+                val nodeLinks = arbitrator.connectedNodeLinks
+                if(nodeLinks.isNotEmpty()) {
+                    var handled = false
+                    val requestId = makeRequestId()
+                    nodeLinks.forEach {
+                        it.sendSessionInformationRequest(requestId) { b, any ->
+                            // on first response from network, use the value
+                            if(!handled) {
+                                handled = true
+                                nodeLinks.forEach { link ->
+                                    if (link != it) {
+                                        link.cancelSessionInfoRequest(requestId)
+                                    }
+                                }
+                                handleSessionInfo(b, any)
+                            }
                         }
                     }
                 }
             }
         }
+    }
+
+    private fun handleSessionInfo(status: Boolean, any: Any?) {
+        // if we've timed out waiting for the message, then use that state
+        // to help us identify NO_ROUTE connection state.
+        if(!status) {
+            sessionInfoTimeout = true
+            return
+        }
+
+        val info = any as SessionInformation
+
+        // if the session information has changed, then we need to finish the previous log session.
+        if(sessionInfo != info) {
+            logTransferCompleteCallback()
+            logTransferLink = null
+            uploadState = ProbeUploadState.Unavailable
+            Log.i(LOG_TAG, "PM($serialNumber): finished log transfer.")
+        }
+
+        sessionInfo = info
+        _probe.value = _probe.value.copy(sessionInfo = info)
     }
 
     private fun updateDataFromAdvertisement(advertisement: CombustionAdvertisingData) {
@@ -709,25 +759,12 @@ internal class ProbeManager(
         updateBatteryIdColor(advertisement.batteryStatus, advertisement.probeID, advertisement.color)
     }
 
-    private fun updateDataFromProbeStatus(status: ProbeStatus) {
-        if(status.mode == ProbeMode.INSTANT_READ) {
-            updateInstantRead(status.temperatures.values[0])
-        } else if(status.mode == ProbeMode.NORMAL) {
-            statusNotificationsMonitor.activity()
-            predictionMonitor.activity()
+    private fun updateNormalMode(status: ProbeStatus) {
+        statusNotificationsMonitor.activity()
+        predictionMonitor.activity()
 
-            updateTemperatures(status.temperatures, status.virtualSensors)
-            predictionManager.updatePredictionStatus(status.predictionStatus, status.maxSequenceNumber)
-        }
-
-        arbitrator.preferredMeatNetLink?.let {
-            _probe.value = _probe.value.copy(
-                hopCount = it.hopCount
-            )
-        }
-
-        updateBatteryIdColor(status.batteryStatus, status.id, status.color)
-        updateSequenceNumbers(status.minSequenceNumber, status.maxSequenceNumber)
+        updateTemperatures(status.temperatures, status.virtualSensors)
+        predictionManager.updatePredictionStatus(status.predictionStatus, status.maxSequenceNumber)
     }
 
     private fun updateInstantRead(value: Double?) {
@@ -739,6 +776,9 @@ internal class ProbeManager(
         )
         instantReadMonitor.activity()
     }
+
+    private fun updateInstantRead(status: ProbeStatus) =
+        updateInstantRead(status.temperatures.values[0])
 
     private fun updatePredictionInfo(predictionInfo: PredictionManager.PredictionInfo?) {
         _probe.value = _probe.value.copy(
@@ -789,6 +829,20 @@ internal class ProbeManager(
         }
     }
 
+    private fun updateLink() {
+        arbitrator.preferredMeatNetLink?.let {
+            _probe.value = _probe.value.copy(
+                hopCount = it.hopCount,
+                preferredLink = it.mac
+            )
+        } ?: run {
+            _probe.value = _probe.value.copy(
+                hopCount = 0u,
+                preferredLink = ""
+            )
+        }
+    }
+
     private fun updateBatteryIdColor(battery: ProbeBatteryStatus, id: ProbeID, color: ProbeColor) {
         _probe.value = _probe.value.copy(
             batteryStatus = battery,
@@ -801,13 +855,6 @@ internal class ProbeManager(
         _probe.value = _probe.value.copy(
             minSequenceNumber = minSequenceNumber,
             maxSequenceNumber = maxSequenceNumber
-        )
-    }
-
-    private fun updateSessionInfo(info: SessionInformation) {
-        sessionInfo = info
-        _probe.value = _probe.value.copy(
-            sessionInfo = info
         )
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -487,6 +487,10 @@ internal class ProbeManager(
 
     private suspend fun handleProbeStatus(device: ProbeBleDeviceBase, status: ProbeStatus) {
         if(arbitrator.shouldUpdateDataFromProbeStatus(status, sessionInfo)) {
+            updateLink()
+            updateBatteryIdColor(status.batteryStatus, status.id, status.color)
+            updateSequenceNumbers(status.minSequenceNumber, status.maxSequenceNumber)
+
             if(status.mode == ProbeMode.NORMAL) {
                 updateNormalMode(status)
 
@@ -498,10 +502,6 @@ internal class ProbeManager(
             else if(status.mode == ProbeMode.INSTANT_READ) {
                 updateInstantRead(status)
             }
-
-            updateLink()
-            updateBatteryIdColor(status.batteryStatus, status.id, status.color)
-            updateSequenceNumbers(status.minSequenceNumber, status.maxSequenceNumber)
         }
 
         // optimize MeatNet connection resources.  if we have a direct link to a probe we want to

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
@@ -45,7 +45,6 @@ internal open class DeviceInformationBleDevice(
     var hardwareRevision: String? = null
     var modelInformation: ModelInformation? = null
 
-
     override fun disconnect() {
         serialNumber = null
         firmwareVersion = null

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
@@ -105,7 +105,7 @@ internal abstract class ProbeBleDeviceBase() {
     abstract fun observeProbeStatusUpdates(callback: (suspend (status: ProbeStatus) -> Unit)? = null)
 
     // Probe UART Command APIs
-    abstract fun sendSessionInformationRequest(callback: ((Boolean, Any?) -> Unit)? = null)
+    abstract fun sendSessionInformationRequest(reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)? = null)
     abstract fun sendSetProbeColor(color: ProbeColor, callback: ((Boolean, Any?) -> Unit)? = null)
     abstract fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)? = null)
     abstract fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)? = null)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
@@ -241,7 +241,7 @@ internal class SimulatedProbeBleDevice(
         observeStatusUpdatesCallback = callback
     }
 
-    override fun sendSessionInformationRequest(callback: ((Boolean, Any?) -> Unit)?) {
+    override fun sendSessionInformationRequest(reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
         val sessionInformation = SessionInformation(0x12345678u, 5000u)
         callback?.let { it(true, sessionInformation) }
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
@@ -53,8 +53,15 @@ internal open class UartBleDevice(
     class MessageCompletionHandler {
         private val waiting = AtomicBoolean(false)
         private var completionCallback: ((Boolean, Any?) -> Unit)? = null
-        private var requestId: UInt? = null
         private var job: Job? = null
+
+        var requestId: UInt? = null
+            private set
+
+        val isWaiting: Boolean
+            get() {
+                return waiting.get()
+            }
 
         fun handled(result: Boolean, data: Any?, reqId: UInt? = null) {
             // if we are waiting for a specific request id
@@ -96,6 +103,12 @@ internal open class UartBleDevice(
                     cleanup()
                 }
             }
+        }
+
+        fun cancel() {
+            job?.cancel()
+            waiting.set(false)
+            cleanup()
         }
 
         private fun cleanup() {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadLogsResponse.kt
@@ -49,6 +49,10 @@ internal class NodeReadLogsResponse(
     payLoadLength,
     NodeMessageType.LOG
 ) {
+    override fun toString(): String {
+        return "${super.toString()} $success $serialNumber $sequenceNumber"
+    }
+
     companion object {
         private const val MIN_PAYLOAD_LENGTH: UByte = 28u
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadSessionInfoResponse.kt
@@ -46,8 +46,11 @@ internal class NodeReadSessionInfoResponse (
     payloadLength,
     NodeMessageType.SESSION_INFO
 ) {
-    companion object {
+    override fun toString(): String {
+        return "${super.toString()} $success ${sessionInformation.sessionID} ${sessionInformation.samplePeriod}"
+    }
 
+    companion object {
         /// payload length 10 = serial number (4 bytes) + session id (4 bytes) + sample period (s bytes)
         const val PAYLOAD_LENGTH: UByte = 10u
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/DataClasses.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/DataClasses.kt
@@ -49,19 +49,18 @@ internal data class RecordRange(val minSeq: UInt, val maxSeq: UInt) {
  * Upload progress data object
  *
  * @property transferred number of records received
- * @property drops number of dropped records
  * @property expected number of records expected
  */
-internal data class UploadProgress(val transferred: UInt, val drops: UInt, val expected: UInt) {
+internal data class UploadProgress(val transferred: UInt, val expected: UInt) {
     companion object {
-        val NULL_UPLOAD_PROGRESS = UploadProgress(0u, 0u, 0u)
+        val NULL_UPLOAD_PROGRESS = UploadProgress(0u, 0u)
     }
 
-    val isComplete: Boolean get() { return (transferred + drops) == expected }
+    // val isComplete: Boolean get() { return (transferred + drops) == expected }
 
     fun toProbeUploadState() : ProbeUploadState {
         return ProbeUploadState.ProbeUploadInProgress(
-            transferred, drops, expected
+            transferred, expected
         )
     }
 }
@@ -73,24 +72,16 @@ internal data class UploadProgress(val transferred: UInt, val drops: UInt, val e
  * @property sessionMinSequence Starting sequence number.
  * @property sessionMaxSequence Max sequence number.
  * @property totalRecords Total number of transferred record.
- * @property logResponseDropCount Number of dropped log response packets.
- * @property deviceStatusDropCount Number of dropped device status packets.
- * @property droppedRecords Total number of dropped logs.
  */
 internal data class SessionStatus(
     val id: String,
     val sessionMinSequence: UInt,
     val sessionMaxSequence: UInt,
     val totalRecords: UInt,
-    val logResponseDropCount: UInt,
-    val deviceStatusDropCount: UInt,
-    val droppedRecords: List<UInt>
 ) {
     companion object {
         val NULL_SESSION_STATUS = SessionStatus(
-            "", 0u, 0u,
-            0u, 0u, 0u,
-            listOf()
+            "", 0u, 0u, 0u,
         )
     }
 
@@ -99,16 +90,12 @@ internal data class SessionStatus(
             sessionMinSequence,
             sessionMaxSequence,
             totalRecords,
-            logResponseDropCount,
-            deviceStatusDropCount
         )
     }
 
     override fun toString(): String {
-        return String.format("%s: %d - %d [%d] [%d] [%d] [%d]",
-            id, sessionMinSequence.toInt(), sessionMaxSequence.toInt(),
-            totalRecords.toInt(), deviceStatusDropCount.toInt(),
-            logResponseDropCount.toInt(),
-            droppedRecords.size)
+        return String.format("%s: %d - %d [%d]",
+            id, sessionMinSequence.toInt(), sessionMaxSequence.toInt(), totalRecords.toInt()
+        )
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/DataClasses.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/DataClasses.kt
@@ -51,16 +51,14 @@ internal data class RecordRange(val minSeq: UInt, val maxSeq: UInt) {
  * @property transferred number of records received
  * @property expected number of records expected
  */
-internal data class UploadProgress(val transferred: UInt, val expected: UInt) {
+internal data class UploadProgress(val transferred: UInt, val expected: UInt, val requested: UInt) {
     companion object {
-        val NULL_UPLOAD_PROGRESS = UploadProgress(0u, 0u)
+        val NULL_UPLOAD_PROGRESS = UploadProgress(0u, 0u, 0u)
     }
-
-    // val isComplete: Boolean get() { return (transferred + drops) == expected }
 
     fun toProbeUploadState() : ProbeUploadState {
         return ProbeUploadState.ProbeUploadInProgress(
-            transferred, expected
+            transferred, expected, requested
         )
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -109,7 +109,11 @@ internal class LogManager {
                                     if(DeviceManager.instance.settings.autoLogTransfer) {
                                         probeManager.sessionInfo?.let {
                                             // note, this will transfer to ProbeUploadInProgress
-                                            requestLogsFromDevice(probeManager.serialNumber)
+                                            requestLogsFromDevice(
+                                                serialNumber = probeManager.serialNumber,
+                                                minSequenceNumber = deviceStatus.minSequenceNumber,
+                                                maxSequenceNumber = deviceStatus.maxSequenceNumber,
+                                            )
                                         }
                                     }
                                     else {
@@ -218,15 +222,24 @@ internal class LogManager {
         temperatureLogs.clear()
     }
 
-    fun requestLogsFromDevice(serialNumber: String) {
+    /**
+     * Starts a log request for [serialNumber]. If [minSequenceNumber] or [maxSequenceNumber] are
+     * non-null, they will be used to set up the initial internal session parameters. If they're
+     * null, cached sequence numbers are used.
+     */
+    fun requestLogsFromDevice(
+        serialNumber: String,
+        minSequenceNumber: UInt? = null,
+        maxSequenceNumber: UInt? = null
+    ) {
         val probeManager = probes[serialNumber] ?: return
         val log = temperatureLogs[serialNumber] ?: return
         val sessionInfo = probeManager.sessionInfo ?: return
 
         // prepare log for the request and determine the needed range
         val range =  log.prepareForLogRequest(
-            probeManager.minSequenceNumber,
-            probeManager.maxSequenceNumber,
+            minSequenceNumber ?: probeManager.minSequenceNumber,
+            maxSequenceNumber ?: probeManager.maxSequenceNumber,
             sessionInfo
         )
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -82,7 +82,7 @@ internal class LogManager {
             // monitor this probes device status flow
             probeManager.addJob(owner.lifecycleScope.launch {
                 owner.repeatOnLifecycle(Lifecycle.State.CREATED) {
-                    probeManager.probeStatusFlow
+                    probeManager.normalModeProbeStatusFlow
                         .onCompletion {
                             Log.d(LOG_TAG, "Probe Status Flow Complete")
                         }
@@ -90,6 +90,14 @@ internal class LogManager {
                             Log.i(LOG_TAG, "Probe Status Flow Catch: $it")
                         }
                         .collect { deviceStatus ->
+                            // LogManager only operates on Normal mode status updates, only
+                            // Normal Mode packets should be published to the flow.  Defensive
+                            // check and log message.
+                            if(deviceStatus.mode != ProbeMode.NORMAL) {
+                                Log.w(LOG_TAG, "Non-Normal mode packet collected on flow!")
+                                return@collect
+                            }
+
                             when(probeManager.uploadState) {
                                 // if upload state is currently unavailable, and we now have a
                                 // ProbeStatus, then we have everything we need to start an upload.
@@ -98,10 +106,7 @@ internal class LogManager {
                                 // the record transfer when they are ready.
                                 ProbeUploadState.Unavailable -> {
                                     if(DeviceManager.instance.settings.autoLogTransfer) {
-                                        if(probeManager.sessionInfo == null) {
-                                            probeManager.fetchSessionInfo()
-                                        }
-                                        else {
+                                        probeManager.sessionInfo?.let {
                                             // note, this will transfer to ProbeUploadInProgress
                                             requestLogsFromDevice(probeManager.serialNumber)
                                         }
@@ -114,10 +119,6 @@ internal class LogManager {
                                     // else, do nothing, wait for the client to request the transfer
                                 }
                                 is ProbeUploadState.ProbeUploadInProgress -> {
-                                    // only log normal mode packets
-                                    if(deviceStatus.mode != ProbeMode.NORMAL)
-                                        return@collect
-
                                     // add device status data points to the log while the upload
                                     // is in progress.  don't event the status, because we will
                                     // do that below in processing the log response.
@@ -126,23 +127,17 @@ internal class LogManager {
                                     // update the count of records downloaded
                                     probeManager.recordsDownloaded = temperatureLog.dataPointCount
 
-                                    // not receiving expected log responses, then complete the log
-                                    // request and transition state.
-                                    if(temperatureLog.logRequestIsStalled) {
-                                        handleStalledLogRequest(temperatureLog, probeManager)
+                                    // complete the request, and change the state to complete
+                                    if(temperatureLog.logRequestIsComplete()) {
+                                        val sessionStatus = temperatureLog.completeLogRequest()
+                                        probeManager.uploadState = sessionStatus.toProbeUploadState()
                                     }
+
                                 }
                                 is ProbeUploadState.ProbeUploadComplete -> {
                                     if(DebugSettings.DEBUG_LOG_LOG_MANAGER_IO) {
-                                        Log.d(
-                                            LOG_TAG, "STATUS-RX : " +
-                                                    "${deviceStatus.maxSequenceNumber}"
-                                        )
+                                        Log.d(LOG_TAG, "STATUS-RX : ${deviceStatus.maxSequenceNumber}")
                                     }
-
-                                    // only log normal mode packets
-                                    if(deviceStatus.mode != ProbeMode.NORMAL)
-                                        return@collect
 
                                     // add the device status to the temperature log
                                     val sessionStatus = temperatureLog.addFromDeviceStatus(deviceStatus)
@@ -150,16 +145,11 @@ internal class LogManager {
                                     // update the count of records downloaded
                                     probeManager.recordsDownloaded = temperatureLog.dataPointCount
 
-                                    // not receiving expected log responses, then complete the log
-                                    // request and transition state.
-                                    if(temperatureLog.logRequestIsStalled) {
-                                        handleStalledLogRequest(temperatureLog, probeManager)
-                                    }
                                     // if we have any dropped records then initiate a log request to
                                     // backfill from the missing records.
-                                    else if(sessionStatus.droppedRecords.isNotEmpty()) {
-                                        val range = RecordRange(sessionStatus.droppedRecords.first(), sessionStatus.droppedRecords.last() + 1u)
-                                        startBackfillLogRequest(temperatureLog, probeManager, range, deviceStatus.maxSequenceNumber)
+                                    val missingRecords = temperatureLog.missingRecordRange(deviceStatus.minSequenceNumber, deviceStatus.maxSequenceNumber)
+                                    if(missingRecords != null) {
+                                        startBackfillLogRequest(temperatureLog, probeManager, missingRecords, deviceStatus.maxSequenceNumber)
                                     }
                                     // we've synchronized the log on the device here, now maintain
                                     // the log with the data points from the device status message.
@@ -194,15 +184,8 @@ internal class LogManager {
                             // update the count of records downloaded
                             probeManager.recordsDownloaded = temperatureLog.dataPointCount
 
-                            // if we aren't complete, then update the stats of the uploading state
-                            if(!uploadProgress.isComplete) {
-                                probeManager.uploadState = uploadProgress.toProbeUploadState()
-                            }
-                            // otherwise complete the request, and change the state to complete
-                            else {
-                                val sessionStatus = temperatureLog.completeLogRequest()
-                                probeManager.uploadState = sessionStatus.toProbeUploadState()
-                            }
+                            // update ProbeManager state
+                            probeManager.uploadState = uploadProgress.toProbeUploadState()
                     }
                 }
             })
@@ -293,7 +276,7 @@ internal class LogManager {
                     // into the flow for the consumer.  if we are no longer in an upload complete
                     // syncing state, then exit out of this flow.
                     val sessionId = log.currentSessionId
-                    probeManager.probeStatusFlow
+                    probeManager.normalModeProbeStatusFlow
                         .collect { deviceStatus ->
                             if(probeManager.uploadState !is ProbeUploadState.ProbeUploadInProgress &&
                                 probeManager.uploadState !is ProbeUploadState.ProbeUploadComplete)  {
@@ -314,18 +297,6 @@ internal class LogManager {
                 }
             }
         }
-    }
-
-
-    private fun handleStalledLogRequest(
-        log: ProbeTemperatureLog,
-        probeManager: ProbeManager,
-    ) {
-        log.completeLogRequest()
-
-        // transition to Unavailable, the next device status will
-        // trigger a log transfer and change state back to in progress.
-        probeManager.uploadState = ProbeUploadState.Unavailable
     }
 
     private fun startBackfillLogRequest(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
@@ -55,12 +55,10 @@ internal class ProbeTemperatureLog(private val serialNumber: String) {
             return _dataPoints
         }
 
-    val logRequestIsStalled: Boolean get() = sessions.lastOrNull()?.logRequestIsStalled ?: false
     val currentSessionId: UInt get() = sessions.lastOrNull()?.id ?: 0u
     val currentSessionSamplePeriod: UInt get() = sessions.lastOrNull()?.samplePeriod ?: 0u
     val currentSessionStartTime: Date? get() = sessions.lastOrNull()?.startTime
     val logStartTime: Date? get() = sessions.firstOrNull()?.startTime
-    val droppedRecords: List<UInt>? get() = sessions.firstOrNull()?.droppedRecords
 
     val dataPointCount: Int
         get() {
@@ -70,6 +68,15 @@ internal class ProbeTemperatureLog(private val serialNumber: String) {
             }
             return count
         }
+
+    fun missingRecordRange(start: UInt, end: UInt): RecordRange? {
+        return sessions.lastOrNull()?.missingRecordRange(start, end)
+    }
+
+    private val logRequestIsStalled: Boolean get() = sessions.lastOrNull()?.logRequestIsStalled ?: false
+    fun logRequestIsComplete(): Boolean {
+        return logRequestIsStalled
+    }
 
     fun prepareForLogRequest(deviceMinSequence: UInt, deviceMaxSequence: UInt, sessionInfo: SessionInformation) : RecordRange {
         var minSeq = 0u

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/ProbeTemperatureLog.kt
@@ -69,6 +69,10 @@ internal class ProbeTemperatureLog(private val serialNumber: String) {
             return count
         }
 
+    fun missingRecordsForRange(start: UInt, end: UInt): UInt? {
+        return sessions.lastOrNull()?.missingRecordsForRange(start, end)
+    }
+
     fun missingRecordRange(start: UInt, end: UInt): RecordRange? {
         return sessions.lastOrNull()?.missingRecordRange(start, end)
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/Session.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/Session.kt
@@ -113,7 +113,7 @@ internal class Session(
                 }
             }
 
-            val upperBound = upper ?: lower
+            val upperBound = upper ?: (lower + 1u)
 
             return RecordRange(lower, upperBound)
         }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
@@ -103,7 +103,8 @@ data class Probe(
     val predictionStale: Boolean = false,
     val overheatingSensors: List<Int> = listOf(),
     val recordsDownloaded: Int = 0,
-    val preferredLink: String = ""
+    val preferredLink: String = "",
+    val logUploadPercent: UInt = 0u
 ) {
     val serialNumber = baseDevice.serialNumber
     val mac = baseDevice.mac

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeUploadState.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeUploadState.kt
@@ -50,6 +50,7 @@ sealed class ProbeUploadState {
      */
     data class ProbeUploadInProgress(
         val recordsTransferred: UInt,
+        val recordsExpected: UInt,
         val recordsRequested: UInt
     ) : ProbeUploadState()
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeUploadState.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ProbeUploadState.kt
@@ -46,12 +46,10 @@ sealed class ProbeUploadState {
      * Upload is in progress.
      *
      * @property recordsTransferred Number of records transferred statistic
-     * @property logResponseDropCount Total number of dropped record transfer logs statistic
      * @property recordsRequested Number of records requested for transfer statistic
      */
     data class ProbeUploadInProgress(
         val recordsTransferred: UInt,
-        val logResponseDropCount: UInt,
         val recordsRequested: UInt
     ) : ProbeUploadState()
 
@@ -61,14 +59,10 @@ sealed class ProbeUploadState {
      * @property sessionMinSequence Min sequence number on phone for current session.
      * @property sessionMaxSequence Max sequence number on phone for current session.
      * @property totalRecords Total number of records on the phone for current session.
-     * @property logResponseDropCount Total number of dropped record transfer logs statistic
-     * @property deviceStatusDropCount Total number of dropped device status records statistic
      */
     data class ProbeUploadComplete(
         val sessionMinSequence: UInt,
         val sessionMaxSequence: UInt,
         val totalRecords: UInt,
-        val logResponseDropCount: UInt,
-        val deviceStatusDropCount: UInt
     ) : ProbeUploadState()
 }


### PR DESCRIPTION
- DROID-241, DROID-243: Refactor how missing records are determined.
- DROID-241, DROID-243: Transition to upload complete when 2 device status messages have been received w/o a log response. 
- DROID-238: Setup node message completion handling based on request id.
- DROID-238: 30 second session info response indicates no route.
- DROID-238: Send Requests to all nodes and handle first response (excluding log requests)
- DROID-238: Remove Monitor MeatNet coroutine (i.e. SessionInfo ping).
- DROID-238: Accept ProbeStatus messages over any MeatNet node and update arbitration logic.
- DROID-238, DROID-242: Remove message handling based on serial number.
- DROID-238, DROID-242: Request all device information (until response is received) and session info on every probe status message.
- DROID-236: Add Log Upload Percent
- DROID-236: Add expected number of new logs to UploadProgress
