### PR TITLE
DROID-278: PoC Producing/Consuming Probe Status

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -266,15 +266,15 @@ internal class ProbeManager(
         private set
 
     // current minimum sequence number for the probe
-    val minSequenceNumber: UInt
+    val minSequenceNumber: UInt?
         get() {
-            return _probe.value.minSequenceNumber
+            return _probe.value.minSequence
         }
 
     // current maximum sequence number for the probe
-    val maxSequenceNumber: UInt
+    val maxSequenceNumber: UInt?
         get() {
-            return _probe.value.maxSequenceNumber
+            return _probe.value.maxSequence
         }
 
     // signals when logs are no longer being added to LogManager.
@@ -864,8 +864,8 @@ internal class ProbeManager(
 
     private fun updateSequenceNumbers(minSequenceNumber: UInt, maxSequenceNumber: UInt) {
         _probe.value = _probe.value.copy(
-            minSequenceNumber = minSequenceNumber,
-            maxSequenceNumber = maxSequenceNumber
+            minSequence = minSequenceNumber,
+            maxSequence = maxSequenceNumber
         )
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/log/LogManager.kt
@@ -238,8 +238,8 @@ internal class LogManager {
 
         // prepare log for the request and determine the needed range
         val range =  log.prepareForLogRequest(
-            minSequenceNumber ?: probeManager.minSequenceNumber,
-            maxSequenceNumber ?: probeManager.maxSequenceNumber,
+            minSequenceNumber ?: probeManager.minSequenceNumber ?: 0u,
+            maxSequenceNumber ?: probeManager.maxSequenceNumber ?: 0u,
             sessionInfo
         )
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
@@ -73,7 +73,8 @@ package inc.combustion.framework.service
  * @see ProbeColor
  * @see ProbeMode
  */
-data class Probe(
+data class Probe
+constructor(
     val baseDevice: Device,
     val sessionInfo: SessionInformation? = null,
     val temperaturesCelsius: ProbeTemperatures? = null,
@@ -83,8 +84,18 @@ data class Probe(
     val coreTemperatureCelsius: Double? = null,
     val surfaceTemperatureCelsius: Double? = null,
     val ambientTemperatureCelsius: Double? = null,
-    val minSequenceNumber: UInt = 0u,
-    val maxSequenceNumber: UInt = 0u,
+    val minSequence: UInt? = null,
+    val maxSequence: UInt? = null,
+    @Deprecated(
+      message = "This field will be removed in a future release",
+      level = DeprecationLevel.WARNING
+    )
+    val minSequenceNumber: UInt = minSequence ?: 0u,
+    @Deprecated(
+        message = "This field will be removed in a future release",
+        level = DeprecationLevel.WARNING
+    )
+    val maxSequenceNumber: UInt = maxSequence ?: 0u,
     val uploadState: ProbeUploadState = ProbeUploadState.Unavailable,
     val id: ProbeID = ProbeID.ID1,
     val color: ProbeColor = ProbeColor.COLOR1,
@@ -104,7 +115,7 @@ data class Probe(
     val overheatingSensors: List<Int> = listOf(),
     val recordsDownloaded: Int = 0,
     val preferredLink: String = "",
-    val logUploadPercent: UInt = 0u
+    val logUploadPercent: UInt = 0u,
 ) {
     val serialNumber = baseDevice.serialNumber
     val mac = baseDevice.mac


### PR DESCRIPTION
- Make min/max sequence number optional to be consistent with iOS.
- Add a deprecation warning to the existing fields.

https://github.com/combustion-inc/combustion-android-prod/pull/109