### PR TITLE
DROID-281: Add EWMA-smoothed RSSI support for probes

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceDiscoveredEvent.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceDiscoveredEvent.kt
@@ -1,0 +1,50 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: DeviceDiscoveredEvent.kt
+ * Author: Nick Helseth <nick@combustion.inc>
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.service
+
+sealed class DeviceDiscoveredEvent {
+    /**
+     * Combustion probe discovered with serial number [serialNumber].
+     */
+    data class ProbeDiscovered(
+        val serialNumber: String
+    ) : DeviceDiscoveredEvent()
+
+    /**
+     * Combustion node discovered with serial number [serialNumber].
+     */
+    data class NodeDiscovered(
+        val serialNumber: String
+    ) : DeviceDiscoveredEvent()
+
+    /**
+     * The device cache was cleared.
+     */
+    object DevicesCleared: DeviceDiscoveredEvent()
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -230,6 +230,19 @@ class DeviceManager(
         }
 
     /**
+     * Kotlin flow for collecting [DeviceDiscoveredEvent]s that occur when the service encounters a
+     * device that is in proximity. To receive updates to the proximity value, collect on the
+     * [deviceSmoothedRssiFlow]. This is a hot flow.
+     *
+     * Note that this flow will emit events for all devices in proximity, disregarding any whitelist
+     * information.
+     */
+    val deviceProximityFlow : SharedFlow<DeviceDiscoveredEvent>
+        get() {
+            return NetworkManager.deviceProximityFlow
+        }
+
+    /**
      * Kotlin flow for collecting NetworkState
      *
      * @see NetworkEvent
@@ -316,6 +329,22 @@ class DeviceManager(
      */
     fun probe(serialNumber: String): Probe? {
         return NetworkManager.instance.probeState(serialNumber)
+    }
+
+    /**
+     * Retrieves the Kotlin flow for collecting current smoothed RSSI value updates for the device
+     * with serial number [serialNumber]. Note that the value retrieved from this flow disregards
+     * MeatNet connections--you may have a MeatNet connection to this device, but if the device
+     * itself is nearly out of range, this flow may have a very low value, may not be updating at
+     * all, or may emit null to indicate that the device is out of range.
+     *
+     * The rate that this flow updates is dependent on if the device is directly connected to this
+     * app (in which case the RSSI value is polled) and the mode that the device is in if
+     * connected to MeatNet (in which case we use advertising data, which can come in more or less
+     * frequently if the probe is in instant read mode or not).
+     */
+    fun deviceSmoothedRssiFlow(serialNumber: String): StateFlow<Double?>? {
+        return NetworkManager.instance.deviceSmoothedRssiFlow(serialNumber)
     }
 
     /**

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Ewma.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Ewma.kt
@@ -1,0 +1,53 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: Ewma.kt
+ * Author:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.service
+
+internal class Ewma(
+    span: UInt,
+) {
+    private var alpha = if (span == 0u) 1.0 else 2.0 / (span.toFloat() + 1.0)
+    private var currentValue: Double? = null
+
+    val value: Double?
+        get() = currentValue
+
+    fun put(value: Double) {
+        currentValue = currentValue?.let {
+            alpha * value + (1.0 - alpha) * it
+        } ?: value
+    }
+
+    fun set(value: Double) {
+        currentValue = value
+    }
+
+    fun reset() {
+        currentValue = null
+    }
+}


### PR DESCRIPTION
Please take a close eye at the API here--my goals are to:
* expose when devices are encountered (see `DeviceManager.deviceProximityFlow`); and
* make it straightforward to collect smoothed RSSI data (see `DeviceManager.deviceSmoothedRssiFlow`) from the device

This is aimed very specifically at probes in this PR, but the API shouldn't preclude adding support for nodes transparently at a later date.