### PR TITLE
Disable Read RSSI while Connected

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/BleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/BleDevice.kt
@@ -249,6 +249,7 @@ internal open class BleDevice (
         }
 
         // but only need one long running thread for this device to read the RSSI while connected.
+        /* TODO: See DROID-319
         if(remoteRssiJob == null) {
             val job = owner.lifecycleScope.launch(Dispatchers.IO) {
                 var exceptionCount = 0;
@@ -281,6 +282,7 @@ internal open class BleDevice (
             remoteRssiJob = job
             jobManager.addJob(job)
         }
+        */
     }
 
     fun observeAdvertisingPackets(filter: (advertisement: CombustionAdvertisingData) -> Boolean, callback: (suspend (advertisement: CombustionAdvertisingData) -> Unit)? = null) {


### PR DESCRIPTION
UART writes would deadlock, and no commands would make it over the network.  This works around that issue and avoids the deadlock.

- Tested 2 direct connected probes.
- Tested with 3 probes and two nodes.  I do see occasional drops on the response over MeatNet, but the value made it to the probe as observed by the setting on the app/timer; so confident that the write made it to MeatNet.