### PR TITLE
Remove publishing block from gradle build.

### DIFF
--- a/combustion-android-ble/build.gradle.kts
+++ b/combustion-android-ble/build.gradle.kts
@@ -109,6 +109,8 @@ dependencies {
 }
 
 afterEvaluate {
+    // TODO: Determine proper publishing configuration(s).
+    /*
     publishing {
         publications {
             // Creates a Maven publication called "release".
@@ -133,4 +135,6 @@ afterEvaluate {
             }
         }
     }
+
+     */
 }


### PR DESCRIPTION
Fixes an issue with the wrong library configuration(s) being published to jitpack. See [this slack thread](https://sasquatch-collective.slack.com/archives/C031NP7Q0ER/p1704913666052869) for more information.

Tested by setting:

```
combustionAndroidBleDevelopSnapshot = "bugfix~fix_publishing_issues-SNAPSHOT"
```

In the prod app's `libs.versions.toml` and removing `combustion.properties` in the app build to emulate the jitpack environment.