### PR TITLE
DROID-418: Update FoodSafe integrated products to latest requirements

### DIFF
--- a/combustion-android-ble/build.gradle.kts
+++ b/combustion-android-ble/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     androidTestImplementation(frameworkLibs.androidx.test.espresso)
     testImplementation(frameworkLibs.junit)
     testImplementation(frameworkLibs.kotlin.test.junit)
+    testImplementation(frameworkLibs.junit.params)
 }
 
 afterEvaluate {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/FoodSafeData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/FoodSafeData.kt
@@ -310,32 +310,40 @@ sealed class FoodSafeData {
 
             data[0] =
                 rawMode or
-                (rawProduct shl 3).toUByte()
+                        (rawProduct shl 3).toUByte()
 
             data[1] =
                 (rawProduct shr 5).toUByte() or
-                (serving.toRaw.toUShort() shl 5).toUByte()
+                        (serving.toRaw.toUShort() shl 5).toUByte()
 
-            val toPacked: (Double) -> UInt = {
-                value -> (value / 0.05).roundToInt().toUInt() and 0x1FFFu
+            val toPacked: (Double) -> UInt = { value ->
+                (value / 0.05).roundToInt().toUInt() and 0x1FFFu
             }
 
-            val rawSelectedThreshold = toPacked(when (this) {
-                is Simplified -> 0.0
-                is Integrated -> this.completionCriteria.selectedThresholdReferenceTemperature
-            })
-            val rawZValue = toPacked(when (this) {
-                is Simplified -> 0.0
-                is Integrated -> this.completionCriteria.zValue
-            })
-            val rawReferenceTemperature = toPacked(when (this) {
-                is Simplified -> 0.0
-                is Integrated -> this.completionCriteria.referenceTemperature
-            })
-            val rawDValueAtRt = toPacked(when (this) {
-                is Simplified -> 0.0
-                is Integrated -> this.completionCriteria.dValueAtRt
-            })
+            val rawSelectedThreshold = toPacked(
+                when (this) {
+                    is Simplified -> 0.0
+                    is Integrated -> this.completionCriteria.selectedThresholdReferenceTemperature
+                }
+            )
+            val rawZValue = toPacked(
+                when (this) {
+                    is Simplified -> 0.0
+                    is Integrated -> this.completionCriteria.zValue
+                }
+            )
+            val rawReferenceTemperature = toPacked(
+                when (this) {
+                    is Simplified -> 0.0
+                    is Integrated -> this.completionCriteria.referenceTemperature
+                }
+            )
+            val rawDValueAtRt = toPacked(
+                when (this) {
+                    is Simplified -> 0.0
+                    is Integrated -> this.completionCriteria.dValueAtRt
+                }
+            )
             val rawTargetLogReduction = when (this) {
                 is Simplified -> 0u
                 is Integrated -> (this.completionCriteria.targetLogReduction / 0.1).toUInt() and 0xFFu
@@ -346,25 +354,25 @@ sealed class FoodSafeData {
 
             data[3] =
                 ((rawSelectedThreshold and 0b1_1111_0000_0000u) shr 8).toUByte() or
-                ((rawZValue and 0b0_0000_0000_0111u) shl 5).toUByte()
+                        ((rawZValue and 0b0_0000_0000_0111u) shl 5).toUByte()
 
             data[4] =
                 ((rawZValue and 0b0_0111_1111_1000u) shr 3).toUByte()
 
             data[5] =
                 ((rawZValue and 0b1_1000_0000_0000u) shr 11).toUByte() or
-                ((rawReferenceTemperature and 0b0_0000_0011_1111u) shl 2).toUByte()
+                        ((rawReferenceTemperature and 0b0_0000_0011_1111u) shl 2).toUByte()
 
             data[6] =
                 ((rawReferenceTemperature and 0b1_1111_1100_0000u) shr 6).toUByte() or
-                ((rawDValueAtRt and 0b0_0000_0000_0001u) shl 7).toUByte()
+                        ((rawDValueAtRt and 0b0_0000_0000_0001u) shl 7).toUByte()
 
             data[7] =
                 ((rawDValueAtRt and 0b0_0001_1111_1110u) shr 1).toUByte()
 
             data[8] =
                 ((rawDValueAtRt and 0b1_1110_0000_0000u) shr 9).toUByte() or
-                ((rawTargetLogReduction and 0b0000_1111u) shl 4).toUByte()
+                        ((rawTargetLogReduction and 0b0000_1111u) shl 4).toUByte()
 
             data[9] =
                 (rawTargetLogReduction and 0b1111_0000u shr 4).toUByte()
@@ -383,27 +391,27 @@ sealed class FoodSafeData {
             val rawMode = data[0] and 0b0000_0111u
             val rawProduct =
                 ((data[0].toUShort() and 0b1111_1000u) shr 3) or
-                ((data[1].toUShort() and 0b0001_1111u) shl 5)
+                        ((data[1].toUShort() and 0b0001_1111u) shl 5)
             val rawServing =
                 ((data[1].toUShort() and 0b1110_0000u) shr 5)
 
             val rawSelectedThresholdReferenceTemperature =
                 data[2].toUShort() or
-                ((data[3].toUShort() and 0b0001_1111u) shl 8)
+                        ((data[3].toUShort() and 0b0001_1111u) shl 8)
             val rawZValue =
                 ((data[3].toUShort() and 0b1110_0000u) shr 5) or
-                ((data[4].toUShort() and 0b1111_1111u) shl 3) or
-                ((data[5].toUShort() and 0b0000_0011u) shl 11)
+                        ((data[4].toUShort() and 0b1111_1111u) shl 3) or
+                        ((data[5].toUShort() and 0b0000_0011u) shl 11)
             val rawReferenceTemperature =
                 ((data[5].toUShort() and 0b1111_1100u) shr 2) or
-                ((data[6].toUShort() and 0b0111_1111u) shl 6)
+                        ((data[6].toUShort() and 0b0111_1111u) shl 6)
             val rawDValueAtRt =
                 ((data[6].toUShort() and 0b1000_0000u) shr 7) or
-                ((data[7].toUShort() and 0b1111_1111u) shl 1) or
-                ((data[8].toUShort() and 0b0000_1111u) shl 9)
+                        ((data[7].toUShort() and 0b1111_1111u) shl 1) or
+                        ((data[8].toUShort() and 0b0000_1111u) shl 9)
             val targetLogReduction =
                 ((data[8].toUShort() and 0b1111_0000u) shr 4) or
-                ((data[9].toUShort() and 0b0000_1111u) shl 4)
+                        ((data[9].toUShort() and 0b0000_1111u) shl 4)
 
             try {
                 return when (Mode.fromRaw(rawMode.toUInt())) {
@@ -413,6 +421,7 @@ sealed class FoodSafeData {
                             serving = Serving.fromRaw(rawServing.toUInt()),
                         )
                     }
+
                     Mode.Integrated -> {
                         Integrated(
                             product = Integrated.Product.fromRaw(rawProduct.toUInt()),
@@ -447,6 +456,7 @@ sealed class FoodSafeData {
                     serving = Serving.Immediately,
                 )
             }
+
             Mode.Integrated -> {
                 Integrated(
                     product = Integrated.Product.fromRaw(Random.nextUInt(until = 13u)),

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/FoodSafeData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/FoodSafeData.kt
@@ -187,37 +187,47 @@ sealed class FoodSafeData {
 
         enum class Product {
             Default,
-            Beef,
-            BeefGround,
-            Chicken,
-            ChickenGround,
-            Pork,
-            PorkGround,
-            Ham,
-            HamGround,
-            Turkey,
-            TurkeyGround,
-            Lamb,
-            LambGround,
-            FishAndShellfish,
-            FishAndShellfishGround,
+            Meats,
+            MeatsGround,
+            DeprecatedChicken,
+            PoultryGround,
+            DepracatedPork,
+            DeprecatedPorkGround,
+            DeprecatedHam,
+            DeprecatedHamGround,
+            DeprecatedTurkey,
+            DeprecatedTurkeyGround,
+            DeprecatedLamb,
+            DeprecatedLambGround,
+            Seafood,
+            SeafoodGround,
             DairyMilkLessThan10PercentFat,
-            Game,
+            Other,
+            SeafoodStuffed,
+            Eggs,
+            EggsYolk,
+            EggsWhite,
+            DairyCreamsGreaterThan10PercentFat,
+            DairyOther,
             Custom,
             ;
 
             override fun toString(): String {
                 return when (this) {
                     Default -> "Poultry (Default)"
-                    BeefGround -> "Beef (Ground)"
-                    ChickenGround -> "Chicken (Ground)"
-                    PorkGround -> "Pork (Ground)"
-                    HamGround -> "Ham (Ground)"
-                    TurkeyGround -> "Turkey (Ground)"
-                    LambGround -> "Lamb (Ground)"
-                    FishAndShellfish -> "Fish and Shellfish"
-                    FishAndShellfishGround -> "Fish and Shellfish (Ground)"
+                    MeatsGround -> "Meats (Ground, Chopped, or Stuffed)"
+                    PoultryGround -> "Poultry (Ground, Chopped, or Stuffed)"
+                    DeprecatedPorkGround -> "Pork (Ground, Chopped, or Stuffed)"
+                    DeprecatedHamGround -> "Ham (Ground)"
+                    DeprecatedTurkeyGround -> "Turkey (Ground)"
+                    DeprecatedLambGround -> "Lamb (Ground)"
+                    SeafoodGround -> "Seafood (Ground or Chopped)"
+                    SeafoodStuffed -> "Seafood (Stuffed)"
                     DairyMilkLessThan10PercentFat -> "Dairy - Milk (<10% fat)"
+                    DairyCreamsGreaterThan10PercentFat -> "Dairy - Creams (>10% fat)"
+                    DairyOther -> "Dairy - Ice Cream Mix, Eggnog"
+                    EggsYolk -> "Eggs yolk"
+                    EggsWhite -> "Eggs white"
                     else -> this.name
                 }
             }
@@ -226,22 +236,28 @@ sealed class FoodSafeData {
                 get() {
                     return when (this) {
                         Default -> 0u
-                        Beef -> 1u
-                        BeefGround -> 2u
-                        Chicken -> 3u
-                        ChickenGround -> 4u
-                        Pork -> 5u
-                        PorkGround -> 6u
-                        Ham -> 7u
-                        HamGround -> 8u
-                        Turkey -> 9u
-                        TurkeyGround -> 10u
-                        Lamb -> 11u
-                        LambGround -> 12u
-                        FishAndShellfish -> 13u
-                        FishAndShellfishGround -> 14u
+                        Meats -> 1u
+                        MeatsGround -> 2u
+                        DeprecatedChicken -> 3u
+                        PoultryGround -> 4u
+                        DepracatedPork -> 5u
+                        DeprecatedPorkGround -> 6u
+                        DeprecatedHam -> 7u
+                        DeprecatedHamGround -> 8u
+                        DeprecatedTurkey -> 9u
+                        DeprecatedTurkeyGround -> 10u
+                        DeprecatedLamb -> 11u
+                        DeprecatedLambGround -> 12u
+                        Seafood -> 13u
+                        SeafoodGround -> 14u
                         DairyMilkLessThan10PercentFat -> 15u
-                        Game -> 16u
+                        Other -> 16u
+                        SeafoodStuffed -> 17u
+                        Eggs -> 18u
+                        EggsYolk -> 19u
+                        EggsWhite -> 20u
+                        DairyCreamsGreaterThan10PercentFat -> 21u
+                        DairyOther -> 22u
                         Custom -> 1023u
                     }
                 }
@@ -250,22 +266,28 @@ sealed class FoodSafeData {
                 internal fun fromRaw(raw: UInt): Product {
                     return when (raw) {
                         0u -> Default
-                        1u -> Beef
-                        2u -> BeefGround
-                        3u -> Chicken
-                        4u -> ChickenGround
-                        5u -> Pork
-                        6u -> PorkGround
-                        7u -> Ham
-                        8u -> HamGround
-                        9u -> Turkey
-                        10u -> TurkeyGround
-                        11u -> Lamb
-                        12u -> LambGround
-                        13u -> FishAndShellfish
-                        14u -> FishAndShellfishGround
+                        1u -> Meats
+                        2u -> MeatsGround
+                        3u -> DeprecatedChicken
+                        4u -> PoultryGround
+                        5u -> DepracatedPork
+                        6u -> DeprecatedPorkGround
+                        7u -> DeprecatedHam
+                        8u -> DeprecatedHamGround
+                        9u -> DeprecatedTurkey
+                        10u -> DeprecatedTurkeyGround
+                        11u -> DeprecatedLamb
+                        12u -> DeprecatedLambGround
+                        13u -> Seafood
+                        14u -> SeafoodGround
                         15u -> DairyMilkLessThan10PercentFat
-                        16u -> Game
+                        16u -> Other
+                        17u -> SeafoodStuffed
+                        18u -> Eggs
+                        19u -> EggsYolk
+                        20u -> EggsWhite
+                        21u -> DairyCreamsGreaterThan10PercentFat
+                        22u -> DairyOther
                         1023u -> Custom
                         else -> throw IllegalArgumentException("Invalid integrated product value $raw")
                     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/FoodSafeData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/FoodSafeData.kt
@@ -191,7 +191,7 @@ sealed class FoodSafeData {
             MeatsGround,
             DeprecatedChicken,
             PoultryGround,
-            DepracatedPork,
+            DeprecatedPork,
             DeprecatedPorkGround,
             DeprecatedHam,
             DeprecatedHamGround,
@@ -240,7 +240,7 @@ sealed class FoodSafeData {
                         MeatsGround -> 2u
                         DeprecatedChicken -> 3u
                         PoultryGround -> 4u
-                        DepracatedPork -> 5u
+                        DeprecatedPork -> 5u
                         DeprecatedPorkGround -> 6u
                         DeprecatedHam -> 7u
                         DeprecatedHamGround -> 8u
@@ -270,7 +270,7 @@ sealed class FoodSafeData {
                         2u -> MeatsGround
                         3u -> DeprecatedChicken
                         4u -> PoultryGround
-                        5u -> DepracatedPork
+                        5u -> DeprecatedPork
                         6u -> DeprecatedPorkGround
                         7u -> DeprecatedHam
                         8u -> DeprecatedHamGround

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/service/FoodSafeDataTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/service/FoodSafeDataTest.kt
@@ -28,11 +28,14 @@
 
 package inc.combustion.framework.service
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import junitparams.naming.TestCaseName
+import org.junit.Assert.*
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(JUnitParamsRunner::class)
 class FoodSafeDataTest {
     @Test
     fun `fromRaw Mode`() {
@@ -111,52 +114,73 @@ class FoodSafeDataTest {
         assertEquals(FoodSafeData.Integrated.Product.Default, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.Beef, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.Meats, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.BeefGround, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.MeatsGround, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.Chicken, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedChicken, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.ChickenGround, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.PoultryGround, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.Pork, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DepracatedPork, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.PorkGround, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedPorkGround, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.Ham, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedHam, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.HamGround, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedHamGround, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.Turkey, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedTurkey, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.TurkeyGround, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedTurkeyGround, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.Lamb, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedLamb, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.LambGround, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedLambGround, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.FishAndShellfish, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.Seafood, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.FishAndShellfishGround, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.SeafoodGround, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
         assertEquals(FoodSafeData.Integrated.Product.DairyMilkLessThan10PercentFat, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.Game, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.Other, toProduct(raw))
+        productValue += 1u
+        raw[0] = (0x01u or (productValue shl 3)).toUByte()
+        assertEquals(FoodSafeData.Integrated.Product.SeafoodStuffed, toProduct(raw))
+        productValue += 1u
+        raw[0] = (0x01u or (productValue shl 3)).toUByte()
+        assertEquals(FoodSafeData.Integrated.Product.Eggs, toProduct(raw))
+        productValue += 1u
+        raw[0] = (0x01u or (productValue shl 3)).toUByte()
+        assertEquals(FoodSafeData.Integrated.Product.EggsYolk, toProduct(raw))
+        productValue += 1u
+        raw[0] = (0x01u or (productValue shl 3)).toUByte()
+        assertEquals(FoodSafeData.Integrated.Product.EggsWhite, toProduct(raw))
+        productValue += 1u
+        raw[0] = (0x01u or (productValue shl 3)).toUByte()
+        assertEquals(
+            FoodSafeData.Integrated.Product.DairyCreamsGreaterThan10PercentFat,
+            toProduct(raw)
+        )
+        productValue += 1u
+        raw[0] = (0x01u or (productValue shl 3)).toUByte()
+        assertEquals(FoodSafeData.Integrated.Product.DairyOther, toProduct(raw))
         raw[0] = 0xF9u
         raw[1] = 0x1Fu
         assertEquals(FoodSafeData.Integrated.Product.Custom, toProduct(raw))
@@ -183,7 +207,7 @@ class FoodSafeDataTest {
             0x00u,
             0x00u,
             0x00u,
-            0x00u
+            0x00u,
         )
         assertEquals(FoodSafeData.Serving.Immediately, toServing(raw))
 
@@ -316,9 +340,13 @@ class FoodSafeDataTest {
     }
 
     @Test
-    fun `toRaw and fromRaw translate (integrated)`() {
+    @Parameters(method = "toAndFromRawTranslateIntegratedParams")
+    @TestCaseName("toRaw and fromRaw translate (Integrated) {0}")
+    fun `toRaw and fromRaw translate (integrated)`(
+        givenProduct: FoodSafeData.Integrated.Product,
+    ) {
         val foodSafeData = FoodSafeData.Integrated(
-            product = FoodSafeData.Integrated.Product.DairyMilkLessThan10PercentFat,
+            product = givenProduct,
             serving = FoodSafeData.Serving.CookAndChill,
             completionCriteria = FoodSafeData.Integrated.CompletionCriteria(
                 selectedThresholdReferenceTemperature = 273.05,
@@ -334,4 +362,7 @@ class FoodSafeDataTest {
 
         assertEquals(foodSafeData, convertedFoodSafeData)
     }
+
+    private fun toAndFromRawTranslateIntegratedParams(): Array<FoodSafeData.Integrated.Product> =
+        FoodSafeData.Integrated.Product.values()
 }

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/service/FoodSafeDataTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/service/FoodSafeDataTest.kt
@@ -126,7 +126,7 @@ class FoodSafeDataTest {
         assertEquals(FoodSafeData.Integrated.Product.PoultryGround, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DepracatedPork, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.DeprecatedPork, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
         assertEquals(FoodSafeData.Integrated.Product.DeprecatedPorkGround, toProduct(raw))

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/service/FoodSafeDataTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/service/FoodSafeDataTest.kt
@@ -28,7 +28,9 @@
 
 package inc.combustion.framework.service
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FoodSafeDataTest {
@@ -171,7 +173,18 @@ class FoodSafeDataTest {
             (FoodSafeData.fromRawData(value) as FoodSafeData.Simplified).serving
         }
 
-        val raw = ubyteArrayOf(0x00u, 0b0000_0000u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u, 0x00u)
+        val raw = ubyteArrayOf(
+            0x00u,
+            0b0000_0000u,
+            0x00u,
+            0x00u,
+            0x00u,
+            0x00u,
+            0x00u,
+            0x00u,
+            0x00u,
+            0x00u
+        )
         assertEquals(FoodSafeData.Serving.Immediately, toServing(raw))
 
         raw[1] = 0b0010_0000u

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kableCore = "0.25.1"
 kotlin = "1.8.0"
 nordicsemiDfu = "2.3.2"
 junit = "4.13.2"
+junitParams = "1.1.1"
 androidDesugarJdkLibs = "2.0.3"
 kotlinTestJunit = "1.8.10"
 mavenPublish = "0.25.3"
@@ -25,6 +26,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 kable-core = { group = "com.juul.kable", name = "core", version.ref = "kableCore" }
 kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlinTestJunit" }
 nordicsemi-dfu = { group = "no.nordicsemi.android", name = "dfu", version.ref = "nordicsemiDfu" }
+junit-params = { group = "pl.pragmatists", name = "JUnitParams", version.ref = "junitParams" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
https://linear.app/combustion/issue/DROID-418/update-foods-integrated-mode-parameters-in-ble-framework

### Description
Update FoodSafe Integrated products to latest requirements in spreadsheet https://docs.google.com/spreadsheets/d/1oDlP5sua6cjwPci3izsTixdTFH7BUwA1mXkIBCCoqUk/edit#gid=1179861674

### Tech Notes
- Rename existing products to the new products where it makes sense
- Need to keep all deprecated products and their order, but rename them with prefix "Deprecated"
- Add the new products that did not match existing

**Does my renaming need to be more aggressive?**
