### PR TITLE
Feature/droid 480 bug instant read data not showing up correct on device card

### DIFF
--- a/combustion-android-ble/build.gradle.kts
+++ b/combustion-android-ble/build.gradle.kts
@@ -107,6 +107,7 @@ dependencies {
     testImplementation(frameworkLibs.junit)
     testImplementation(frameworkLibs.kotlin.test.junit)
     testImplementation(frameworkLibs.junit.params)
+    testImplementation(frameworkLibs.mockk.android)
 }
 
 afterEvaluate {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -42,7 +42,7 @@ import inc.combustion.framework.service.DeviceManager
 import inc.combustion.framework.service.ProbeMode
 import inc.combustion.framework.service.SessionInformation
 
-/// Number of seconds to ignore other lower-priority (higher hop count) sources of information for Instant Read
+// Number of seconds to ignore other lower-priority (higher hop count) sources of information for Instant Read
 private const val INSTANT_READ_IDLE_TIMEOUT = 1000L
 
 internal class DataLinkArbitrator(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -73,7 +73,7 @@ internal class DataLinkArbitrator(
 
     val directLink: ProbeBleDevice?
         get() {
-            return if(probeBleDevice?.isConnected == true) probeBleDevice else null
+            return if (probeBleDevice?.isConnected == true) probeBleDevice else null
         }
 
     val connectedNodeLinks: List<RepeatedProbeBleDevice>
@@ -84,7 +84,7 @@ internal class DataLinkArbitrator(
     val preferredMeatNetLink: ProbeBleDeviceBase?
         get() {
             // If meatnet is not enabled, then return the probe connection
-            if(!settings.meatNetEnabled) {
+            if (!settings.meatNetEnabled) {
                 return directLink
             }
 
@@ -107,12 +107,12 @@ internal class DataLinkArbitrator(
     val hasMeatNetRoute: Boolean
         get() {
             // only applies when using MeatNet
-            if(!settings.meatNetEnabled) {
+            if (!settings.meatNetEnabled) {
                 return false
             }
 
-            for(probe in repeatedProbeBleDevices)  {
-                if(probe.isConnected && probe.connectionState != DeviceConnectionState.NO_ROUTE) {
+            for (probe in repeatedProbeBleDevices) {
+                if (probe.isConnected && probe.connectionState != DeviceConnectionState.NO_ROUTE) {
                     return true
                 }
             }
@@ -157,8 +157,11 @@ internal class DataLinkArbitrator(
     }
 
     fun addProbe(probe: ProbeBleDevice, baseDevice: DeviceInformationBleDevice): Boolean {
-        if(probeBleDevice == null) {
-            Log.d(LOG_TAG, "DataLinkArbitrator.addProbe(${probe.probeSerialNumber}, ${baseDevice.serialNumber}: ${baseDevice.id})")
+        if (probeBleDevice == null) {
+            Log.d(
+                LOG_TAG,
+                "DataLinkArbitrator.addProbe(${probe.probeSerialNumber}, ${baseDevice.serialNumber}: ${baseDevice.id})"
+            )
             probeBleDevice = probe
             networkNodes[baseDevice.id] = baseDevice
             return true
@@ -167,10 +170,16 @@ internal class DataLinkArbitrator(
         return false
     }
 
-    fun addRepeatedProbe(repeatedProbe: RepeatedProbeBleDevice, repeater: DeviceInformationBleDevice): Boolean {
-        Log.d(LOG_TAG, "DataLinkArbitrator.addRepeatedProbe(${repeatedProbe.probeSerialNumber}, ${repeater.id})")
+    fun addRepeatedProbe(
+        repeatedProbe: RepeatedProbeBleDevice,
+        repeater: DeviceInformationBleDevice
+    ): Boolean {
+        Log.d(
+            LOG_TAG,
+            "DataLinkArbitrator.addRepeatedProbe(${repeatedProbe.probeSerialNumber}, ${repeater.id})"
+        )
         repeatedProbeBleDevices.add(repeatedProbe)
-        if(!networkNodes.containsKey(repeater.id)) {
+        if (!networkNodes.containsKey(repeater.id)) {
             networkNodes[repeater.id] = repeater
         }
         return true
@@ -178,9 +187,9 @@ internal class DataLinkArbitrator(
 
     fun getPreferredConnectionState(state: DeviceConnectionState): ProbeBleDeviceBase? {
         // if not using MeatNet, then use the probe.
-        if(!settings.meatNetEnabled) {
+        if (!settings.meatNetEnabled) {
             probeBleDevice?.let {
-                if(it.connectionState == state) {
+                if (it.connectionState == state) {
                     return it
                 }
 
@@ -190,7 +199,7 @@ internal class DataLinkArbitrator(
 
         // if using MeatNet, prefer probe if state matches.
         probeBleDevice?.let {
-            if(it.connectionState == state) {
+            if (it.connectionState == state) {
                 return it
             }
         }
@@ -209,9 +218,9 @@ internal class DataLinkArbitrator(
         // for meatnet links
         repeatedProbeBleDevices.forEach {
             // should connect to this repeated probe
-            if(shouldConnect(it, fromApiCall)) {
+            if (shouldConnect(it, fromApiCall)) {
                 // if don't already plan to connect to the repeater for the repeated probe
-                if(!connectable.contains(it.id)) {
+                if (!connectable.contains(it.id)) {
                     // add to the list of meatnet devices we need to connect to
                     connectable.add(it.id)
                 }
@@ -220,13 +229,13 @@ internal class DataLinkArbitrator(
 
         // should direct connect to the probe
         probeBleDevice?.let {
-            if(shouldConnect(it, fromApiCall)) {
+            if (shouldConnect(it, fromApiCall)) {
                 connectable.add(it.id)
             }
         }
 
-        return networkNodes.filter {
-            entry: Map.Entry<DeviceID, DeviceInformationBleDevice> -> connectable.contains(entry.key)
+        return networkNodes.filter { entry: Map.Entry<DeviceID, DeviceInformationBleDevice> ->
+            connectable.contains(entry.key)
         }.values.toList()
     }
 
@@ -240,31 +249,30 @@ internal class DataLinkArbitrator(
 
         // Should disconnect from a direct connection to the probe
         probeBleDevice?.let {
-            if(shouldDisconnect(it)) {
+            if (shouldDisconnect(it)) {
                 nodesToDisconnect.add(it.id)
             }
         }
 
         Log.d(LOG_TAG, "DataLinkArbitrator.getNodesNeedingDisconnect: $nodesToDisconnect")
 
-        return networkNodes.filter {
-            entry: Map.Entry<DeviceID, DeviceInformationBleDevice> -> nodesToDisconnect.contains(entry.key)
+        return networkNodes.filter { entry: Map.Entry<DeviceID, DeviceInformationBleDevice> ->
+            nodesToDisconnect.contains(entry.key)
         }.values.toList()
     }
 
     fun shouldConnect(device: ProbeBleDeviceBase, fromApiCall: Boolean = false): Boolean {
         val canConnect = device.isDisconnected && device.isConnectable && !device.isInDfuMode
-        if(settings.meatNetEnabled) {
+        if (settings.meatNetEnabled) {
             // connect to every connectable device when using meatnet
-            if(USE_SIMPLE_MEATNET_CONNECTION_SCHEME) {
+            if (USE_SIMPLE_MEATNET_CONNECTION_SCHEME) {
                 return canConnect
             }
 
             return shouldMultiNodeMeatNetConnect(device)
-        }
-        else if(device is ProbeBleDevice) {
+        } else if (device is ProbeBleDevice) {
             // if not using meatnet, and the client app is asking us to connect
-            if(fromApiCall) {
+            if (fromApiCall) {
                 device.shouldAutoReconnect = settings.autoReconnect
                 return canConnect
             }
@@ -283,28 +291,28 @@ internal class DataLinkArbitrator(
         val canConnect = device.isDisconnected && device.isConnectable && !device.isInDfuMode
 
         // if this is from the network, then return if we can connect
-        if(device is RepeatedProbeBleDevice) {
+        if (device is RepeatedProbeBleDevice) {
             return canConnect
         }
 
         // if we can connect to this direct probe
-        if(canConnect) {
+        if (canConnect) {
 
             // if we have a discovery timestamp
             directLinkDiscoverTimestamp?.let { timestamp ->
 
                 // if the settling timeout has elapsed
-                if(timestamp + MULTINODE_PROBE_SETTLING_TIMEOUT_MS < System.currentTimeMillis()) {
+                if (timestamp + MULTINODE_PROBE_SETTLING_TIMEOUT_MS < System.currentTimeMillis()) {
 
                     // check if we have a MeatNet link
                     val hasMeatNetLink = repeatedProbeBleDevices.firstOrNull {
-                            it.isConnected && it.connectionState != DeviceConnectionState.NO_ROUTE
-                        } != null
+                        it.isConnected && it.connectionState != DeviceConnectionState.NO_ROUTE
+                    } != null
 
                     // connect only if we don't have a MeatNet link.
                     return !hasMeatNetLink
                 }
-            // otherwise, record the discovery timestamp and return false to wait for settling timeout.
+                // otherwise, record the discovery timestamp and return false to wait for settling timeout.
             } ?: run {
                 directLinkDiscoverTimestamp = System.currentTimeMillis()
             }
@@ -353,30 +361,43 @@ internal class DataLinkArbitrator(
         probeBleDevice?.shouldAutoReconnect = shouldAutoReconnect
     }
 
-    fun shouldUpdateDataFromAdvertisingPacket(device: ProbeBleDeviceBase, advertisement: CombustionAdvertisingData): Boolean {
-        return if(!USE_STATIC_LINK) advertisingArbitrator.shouldUpdate(device, advertisement) else debuggingWithStaticLink(device)
+    fun shouldUpdateDataFromAdvertisingPacket(
+        device: ProbeBleDeviceBase,
+        advertisement: CombustionAdvertisingData
+    ): Boolean {
+        return if (!USE_STATIC_LINK) advertisingArbitrator.shouldUpdate(
+            device,
+            advertisement
+        ) else debuggingWithStaticLink(device)
     }
 
     private var currentStatus: ProbeStatus? = null
     private var currentSessionInfo: SessionInformation? = null
     private var currentHopCount: UInt? = null
 
-    fun shouldUpdateDataFromProbeStatus(status: ProbeStatus, sessionInfo: SessionInformation?, hopCount: UInt?): Boolean =
-        when (status.mode) {
-            ProbeMode.INSTANT_READ -> shouldUpdateDataFromProbeStatusForInstantReadMode(hopCount)
-            else -> shouldUpdateDataFromProbeStatusForNormalMode(status, sessionInfo)
-        }
+    fun shouldUpdateDataFromProbeStatus(
+        status: ProbeStatus,
+        sessionInfo: SessionInformation?,
+        hopCount: UInt?,
+    ): Boolean = when (status.mode) {
+        ProbeMode.INSTANT_READ -> shouldUpdateDataFromProbeStatusForInstantReadMode(hopCount)
+        else -> shouldUpdateDataFromProbeStatusForNormalMode(status, sessionInfo)
+    }
 
-    private fun shouldUpdateDataFromProbeStatusForNormalMode(status: ProbeStatus, sessionInfo: SessionInformation?): Boolean {
+    private fun shouldUpdateDataFromProbeStatusForNormalMode(
+        status: ProbeStatus,
+        sessionInfo: SessionInformation?,
+    ): Boolean {
         currentSessionInfo?.let {
-            if(it != sessionInfo) {
+            if (it != sessionInfo) {
                 currentSessionInfo = sessionInfo
                 currentStatus = status
                 return true
             }
 
             // if status.max > current.max, then we want to update
-            val shouldUpdate = status.maxSequenceNumber > (currentStatus?.maxSequenceNumber ?: UInt.MAX_VALUE)
+            val shouldUpdate =
+                status.maxSequenceNumber > (currentStatus?.maxSequenceNumber ?: UInt.MAX_VALUE)
 
             currentStatus = status
 
@@ -408,11 +429,13 @@ internal class DataLinkArbitrator(
     }
 
     fun shouldUpdateOnRemoteRssi(device: ProbeBleDeviceBase): Boolean {
-        return if(!USE_STATIC_LINK) (device == preferredMeatNetLink) else debuggingWithStaticLink(device)
+        return if (!USE_STATIC_LINK) (device == preferredMeatNetLink) else debuggingWithStaticLink(
+            device
+        )
     }
 
     private fun debuggingWithStaticLink(device: ProbeBleDeviceBase): Boolean {
-        return when(device) {
+        return when (device) {
             is ProbeBleDevice -> true
             is RepeatedProbeBleDevice -> false
             else -> false

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/DataLinkArbitrator.kt
@@ -48,6 +48,7 @@ private const val INSTANT_READ_IDLE_TIMEOUT = 1000L
 internal class DataLinkArbitrator(
     private val settings: DeviceManager.Settings,
     private val instantReadIdleMonitor: IdleMonitor = IdleMonitor(),
+    private var currentHopCount: UInt? = null,
 ) {
     companion object {
         private const val USE_STATIC_LINK: Boolean = false
@@ -373,7 +374,6 @@ internal class DataLinkArbitrator(
 
     private var currentStatus: ProbeStatus? = null
     private var currentSessionInfo: SessionInformation? = null
-    private var currentHopCount: UInt? = null
 
     fun shouldUpdateDataFromProbeStatus(
         status: ProbeStatus,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -32,19 +32,44 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import inc.combustion.framework.InstantReadFilter
 import inc.combustion.framework.LOG_TAG
-import inc.combustion.framework.ble.device.*
+import inc.combustion.framework.ble.device.DeviceID
 import inc.combustion.framework.ble.device.DeviceInformationBleDevice
 import inc.combustion.framework.ble.device.ProbeBleDevice
 import inc.combustion.framework.ble.device.ProbeBleDeviceBase
 import inc.combustion.framework.ble.device.RepeatedProbeBleDevice
+import inc.combustion.framework.ble.device.SimulatedProbeBleDevice
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.ble.uart.LogResponse
-import inc.combustion.framework.service.*
+import inc.combustion.framework.service.DeviceConnectionState
+import inc.combustion.framework.service.DeviceManager
+import inc.combustion.framework.service.FirmwareVersion
+import inc.combustion.framework.service.FoodSafeData
+import inc.combustion.framework.service.FoodSafeStatus
+import inc.combustion.framework.service.ModelInformation
+import inc.combustion.framework.service.Probe
+import inc.combustion.framework.service.ProbeBatteryStatus
+import inc.combustion.framework.service.ProbeColor
+import inc.combustion.framework.service.ProbeID
+import inc.combustion.framework.service.ProbeMode
+import inc.combustion.framework.service.ProbePredictionMode
+import inc.combustion.framework.service.ProbeTemperatures
+import inc.combustion.framework.service.ProbeUploadState
+import inc.combustion.framework.service.ProbeVirtualSensors
+import inc.combustion.framework.service.SessionInformation
 import inc.combustion.framework.service.utils.DefaultLinearizationTimerImpl
 import inc.combustion.framework.service.utils.PredictionManager
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 /**
  * This class is responsible for managing and arbitrating the data links to a temperature
@@ -326,7 +351,7 @@ internal class ProbeManager(
             var updatedProbe = _probe.value
 
             // process simulated device status notifications
-            simProbe.observeProbeStatusUpdates { status ->
+            simProbe.observeProbeStatusUpdates(hopCount = null) { status, _ ->
                 if(status.mode == ProbeMode.NORMAL) {
                     updatedProbe = updateNormalMode(status, updatedProbe)
                     _normalModeProbeStatusFlow.emit(status)
@@ -566,7 +591,7 @@ internal class ProbeManager(
         (base as? RepeatedProbeBleDevice)?.let {
             it.observeMeatNetNodeTimeout(MEATNET_STATUS_NOTIFICATIONS_TIMEOUT_MS)
         }
-        base.observeProbeStatusUpdates { status -> handleProbeStatus(status) }
+        base.observeProbeStatusUpdates(hopCount = base.hopCount) { status, hopCount -> handleProbeStatus(status, hopCount) }
         base.observeRemoteRssi { rssi ->
             _probe.update { handleRemoteRssi(base, rssi, it) }
         }
@@ -603,8 +628,8 @@ internal class ProbeManager(
         )
     }
 
-    private suspend fun handleProbeStatus(status: ProbeStatus) {
-        if(arbitrator.shouldUpdateDataFromProbeStatus(status, sessionInfo)) {
+    private suspend fun handleProbeStatus(status: ProbeStatus, hopCount: UInt?) {
+        if(arbitrator.shouldUpdateDataFromProbeStatus(status, sessionInfo, hopCount)) {
             Log.v(LOG_TAG, "ProbeManager.handleProbeStatus: $serialNumber $status")
 
             var updatedProbe = _probe.value

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
@@ -216,7 +216,7 @@ internal class ProbeBleDevice (
     override fun observeOutOfRange(timeout: Long, callback: (suspend () -> Unit)?) = uart.observeOutOfRange(timeout, callback)
     override fun observeConnectionState(callback: (suspend (newConnectionState: DeviceConnectionState) -> Unit)?) = uart.observeConnectionState(callback)
 
-    override fun observeProbeStatusUpdates(callback: (suspend (status: ProbeStatus) -> Unit)?) {
+    override fun observeProbeStatusUpdates(hopCount: UInt?, callback: (suspend (status: ProbeStatus, hopCount: UInt?) -> Unit)?) {
         if (probeStatusJob?.isActive != true) {
             val job = uart.owner.lifecycleScope.launch(
                 CoroutineName("${probeSerialNumber}.observeProbeStatusUpdates")
@@ -231,7 +231,7 @@ internal class ProbeBleDevice (
                     .collect { data ->
                         ProbeStatus.fromRawData(data.toUByteArray())?.let { status ->
                             callback?.let {
-                                it(status)
+                                it(status, hopCount)
                             }
                         }
                     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDeviceBase.kt
@@ -104,7 +104,7 @@ internal abstract class ProbeBleDeviceBase {
     abstract suspend fun readModelInformation()
 
     // probe status updates
-    abstract fun observeProbeStatusUpdates(callback: (suspend (status: ProbeStatus) -> Unit)? = null)
+    abstract fun observeProbeStatusUpdates(hopCount: UInt?, callback: (suspend (status: ProbeStatus, hopCount: UInt?) -> Unit)? = null)
 
     // Probe UART Command APIs
     abstract fun sendSessionInformationRequest(reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)? = null)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
@@ -64,7 +64,7 @@ internal class RepeatedProbeBleDevice (
     // TODO: Why is this a map? I only see probeSerialNumber being set here.
     private val advertisementForProbe = hashMapOf<String, CombustionAdvertisingData>()
 
-    private var probeStatusCallback: (suspend (status: ProbeStatus) -> Unit)? = null
+    private var probeStatusCallback: (suspend (status: ProbeStatus, hopCount: UInt?) -> Unit)? = null
     private var logResponseCallback: (suspend (LogResponse) -> Unit)? = null
 
     private var _deviceInfoSerialNumber: String? = null
@@ -270,7 +270,7 @@ internal class RepeatedProbeBleDevice (
         uart.observeConnectionState(this::baseConnectionStateHandler)
     }
 
-    override fun observeProbeStatusUpdates(callback: (suspend (status: ProbeStatus) -> Unit)?) {
+    override fun observeProbeStatusUpdates(hopCount: UInt?, callback: (suspend (status: ProbeStatus, hopCount: UInt?) -> Unit)?) {
         probeStatusCallback = callback
     }
 
@@ -356,7 +356,7 @@ internal class RepeatedProbeBleDevice (
         meatNetNodeTimeoutMonitor.activity()
 
         probeStatusCallback?.let {
-            it(message.probeStatus)
+            it(message.probeStatus, message.hopCount.hopCount)
         }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
@@ -102,7 +102,7 @@ internal class SimulatedProbeBleDevice(
     private var observeAdvertisingCallback: (suspend (advertisement: CombustionAdvertisingData) -> Unit)? = null
     private var observeRemoteRssiCallback: (suspend (rssi: Int) -> Unit)? = null
     private var observeConnectionStateCallback: (suspend (newConnectionState: DeviceConnectionState) -> Unit)? = null
-    private var observeStatusUpdatesCallback: (suspend (status: ProbeStatus) -> Unit)? = null
+    private var observeStatusUpdatesCallback: (suspend (status: ProbeStatus, hopCount: UInt?) -> Unit)? = null
 
     override var rssi: Int = randomRSSI()
         private set
@@ -163,7 +163,8 @@ internal class SimulatedProbeBleDevice(
                                 predictionStatus = PredictionStatus.withRandomData(),
                                 foodSafeData = FoodSafeData.RANDOM,
                                 foodSafeStatus = FoodSafeStatus.RANDOM,
-                            )
+                            ),
+                            null,
                         )
                     }
                 }
@@ -239,7 +240,7 @@ internal class SimulatedProbeBleDevice(
         // nothing to do -- handled on connect
     }
 
-    override fun observeProbeStatusUpdates(callback: (suspend (status: ProbeStatus) -> Unit)?) {
+    override fun observeProbeStatusUpdates(hopCount: UInt?, callback: (suspend (status: ProbeStatus, hopCount: UInt?) -> Unit)?) {
         observeStatusUpdatesCallback = callback
     }
 

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/ble/DataLinkArbitratorTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/ble/DataLinkArbitratorTest.kt
@@ -86,7 +86,7 @@ internal class DataLinkArbitratorTest {
         arrayOf(1u, false, null as? UInt?, true),
         arrayOf(2u, false, null as? UInt?, true),
 
-        // when not idle then hopCOunt should be <= currentHopCount
+        // when not idle then hopCount should be <= currentHopCount
         arrayOf(null as? UInt?, false, 0u, false),
         arrayOf(1u, false, 0u, true),
         arrayOf(1u, false, 1u, true),

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/ble/DataLinkArbitratorTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/ble/DataLinkArbitratorTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: DataLinkArbitratorTest.kt
+ * Author:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.ble
+
+import inc.combustion.framework.service.DeviceManager
+import inc.combustion.framework.service.ProbeMode
+import io.mockk.every
+import io.mockk.mockk
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import junitparams.naming.TestCaseName
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(JUnitParamsRunner::class)
+internal class DataLinkArbitratorTest {
+
+    private val probStatus: ProbeStatus = mockk(relaxed = true)
+    private val settings: DeviceManager.Settings = mockk(relaxed = true)
+    private val instantReadIdleMonitor: IdleMonitor = mockk(relaxed = true)
+
+    private fun getTested(currentHopCount: UInt? = null): DataLinkArbitrator {
+        return DataLinkArbitrator(
+            settings = settings,
+            instantReadIdleMonitor = instantReadIdleMonitor,
+            currentHopCount = currentHopCount,
+        )
+    }
+
+    @Test
+    @Parameters(method = "shouldUpdateDataFromProbeStatusForInstantReadModeParams")
+    @TestCaseName("given currentHopCount {0} and isIdle is {1} when get shouldUpdateDataFromProbeStatus for instant read with hopCount {2} then return {3}")
+    fun `given currentHopCount and idle state when get shouldUpdateDataFromProbeStatus for instant read with a hopCount then verify correct return value`(
+        givenCurrentHopCount: UInt?,
+        givenIsIdle: Boolean,
+        givenHopCount: UInt?,
+        expectedValue: Boolean,
+    ) {
+        // given
+        val tested = getTested(currentHopCount = givenCurrentHopCount)
+        every { instantReadIdleMonitor.isIdle(1000L) } returns givenIsIdle
+        every { probStatus.mode } returns ProbeMode.INSTANT_READ
+
+        // when / then
+        assertEquals(
+            expectedValue,
+            tested.shouldUpdateDataFromProbeStatus(
+                status = probStatus,
+                sessionInfo = null,
+                hopCount = givenHopCount
+            )
+        )
+    }
+
+    fun shouldUpdateDataFromProbeStatusForInstantReadModeParams() = arrayOf(
+        // when hopCount is null then always true
+        arrayOf(null as? UInt?, false, null as? UInt?, true),
+        arrayOf(0u, false, null as? UInt?, true),
+        arrayOf(1u, false, null as? UInt?, true),
+        arrayOf(2u, false, null as? UInt?, true),
+
+        // when not idle then hopCOunt should be <= currentHopCount
+        arrayOf(null as? UInt?, false, 0u, false),
+        arrayOf(1u, false, 0u, true),
+        arrayOf(1u, false, 1u, true),
+        arrayOf(1u, false, 2u, false),
+
+        // when idle then always return true
+        arrayOf(null as? UInt?, true, 0u, true),
+        arrayOf(1u, true, 2u, true),
+    )
+}

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/service/FoodSafeDataTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/service/FoodSafeDataTest.kt
@@ -111,44 +111,17 @@ class FoodSafeDataTest {
         }
 
         var productValue = 0x00u
-        assertEquals(FoodSafeData.Integrated.Product.Default, toProduct(raw))
+        assertEquals(FoodSafeData.Integrated.Product.Poultry, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
         assertEquals(FoodSafeData.Integrated.Product.Meats, toProduct(raw))
         productValue += 1u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
         assertEquals(FoodSafeData.Integrated.Product.MeatsGround, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedChicken, toProduct(raw))
-        productValue += 1u
+        productValue += 2u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
         assertEquals(FoodSafeData.Integrated.Product.PoultryGround, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedPork, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedPorkGround, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedHam, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedHamGround, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedTurkey, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedTurkeyGround, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedLamb, toProduct(raw))
-        productValue += 1u
-        raw[0] = (0x01u or (productValue shl 3)).toUByte()
-        assertEquals(FoodSafeData.Integrated.Product.DeprecatedLambGround, toProduct(raw))
-        productValue += 1u
+        productValue += 9u
         raw[0] = (0x01u or (productValue shl 3)).toUByte()
         assertEquals(FoodSafeData.Integrated.Product.Seafood, toProduct(raw))
         productValue += 1u

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ junitParams = "1.1.1"
 androidDesugarJdkLibs = "2.0.3"
 kotlinTestJunit = "1.8.10"
 mavenPublish = "0.25.3"
+mockk = "1.13.9"
 
 [libraries]
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
@@ -27,6 +28,7 @@ kable-core = { group = "com.juul.kable", name = "core", version.ref = "kableCore
 kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlinTestJunit" }
 nordicsemi-dfu = { group = "no.nordicsemi.android", name = "dfu", version.ref = "nordicsemiDfu" }
 junit-params = { group = "pl.pragmatists", name = "JUnitParams", version.ref = "junitParams" }
+mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
https://linear.app/combustion/issue/DROID-480/bug-instant-read-data-not-showing-up-correct-on-device-card

## Description
Fix Intstant sensor not displaying correctly in the app since the logic to determine if data should be updated when probe is in INSTANT_READ mode is dated

Note, with some auto formatting - it is easiest to see the changes with commit https://github.com/combustion-inc/combustion-android-ble/pull/131/commits/b09364afc8f1794f832758576574fb2a3e20265b

## Tech Notes
- port logic from iOS' [Probe.shouldUpdateInstantRead()](https://github.com/combustion-inc/combustion-ios-ble/blob/797416a7944b8f652c7a602981c004703b29c620/Sources/CombustionBLE/Devices/Probe.swift#L467) as `DataLinkArbitrator.shouldUpdateDataFromProbeStatusForInstantReadMode`
- add `hopCount` parameter to methods to have it available to `DataLinkArbitrator.shouldUpdateDataFromProbeStatusForInstantReadMode`
- Fix tests not compiling in `FoodSafeDataTest.fromRaw Integrated Product()`

## Video
### app switches from core to updating instant when squeezing probe which did not happen before
https://github.com/user-attachments/assets/0cd1dd5a-e372-4b9d-9149-3cb74e7a3461

