### PR TITLE
Fix bug with request handling

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -44,7 +44,7 @@ internal class NodeBleDevice(
 
     fun sendNodeRequest(request: GenericNodeRequest, callback: ((Boolean, Any?) -> Unit)?) {
         val nodeRequest = request.toNodeRequest()
-        genericRequestHandler.wait(uart.owner, NODE_MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
+        genericRequestHandler.wait(uart.owner, NODE_MESSAGE_RESPONSE_TIMEOUT_MS, nodeRequest.requestId, callback)
         sendUartRequest(nodeRequest)
     }
 
@@ -95,10 +95,10 @@ internal class NodeBleDevice(
             responses.forEach { response ->
                 when (response) {
                     is NodeReadFeatureFlagsResponse -> {
-                        readFeatureFlagsRequest.handled(response.success, response)
+                        readFeatureFlagsRequest.handled(response.success, response, response.requestId)
                     }
                     is GenericNodeResponse -> {
-                        genericRequestHandler.handled(response.success, response)
+                        genericRequestHandler.handled(response.success, response, response.requestId)
                     } else -> {
                         // drop the message
                         Log.w(LOG_TAG, "NodeBLEDevice: Unhandled response: $response")


### PR DESCRIPTION
The genericRequestHander wasn't tracking the requestId. This caused it to return responses for incorrect messages if other responses were interleaved. Passing the requestId to the wait and handle methods fixes this issue.
