### PR TITLE
Support request forwarding

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -146,6 +146,7 @@ internal class NetworkManager(
     }
 
     companion object {
+        private const val FLOW_CONFIG_NO_REPLAY = 0
         private const val FLOW_CONFIG_REPLAY = 5
         private const val FLOW_CONFIG_BUFFER = FLOW_CONFIG_REPLAY * 2
 
@@ -165,7 +166,7 @@ internal class NetworkManager(
                 FLOW_CONFIG_REPLAY, FLOW_CONFIG_BUFFER, BufferOverflow.SUSPEND
             ),
             mutableGenericNodeRequestFlow = MutableSharedFlow(
-                FLOW_CONFIG_REPLAY, FLOW_CONFIG_BUFFER, BufferOverflow.SUSPEND
+                FLOW_CONFIG_NO_REPLAY, FLOW_CONFIG_BUFFER, BufferOverflow.DROP_OLDEST
             ),
         )
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -71,6 +71,7 @@ internal class NetworkManager(
         var mutableNetworkState: MutableStateFlow<NetworkState>,
         var mutableFirmwareUpdateState: MutableStateFlow<FirmwareState>,
         var mutableDeviceProximityFlow: MutableSharedFlow<DeviceDiscoveredEvent>,
+        var mutableGenericNodeRequestFlow: MutableSharedFlow<GenericNodeRequest>,
     )
 
     inner private class NodeDeviceManager(
@@ -163,6 +164,9 @@ internal class NetworkManager(
             mutableDeviceProximityFlow = MutableSharedFlow(
                 FLOW_CONFIG_REPLAY, FLOW_CONFIG_BUFFER, BufferOverflow.SUSPEND
             ),
+            mutableGenericNodeRequestFlow = MutableSharedFlow(
+                FLOW_CONFIG_REPLAY, FLOW_CONFIG_BUFFER, BufferOverflow.SUSPEND
+            ),
         )
 
         fun initialize(
@@ -211,6 +215,11 @@ internal class NetworkManager(
         val deviceProximityFlow: SharedFlow<DeviceDiscoveredEvent>
             get() {
                 return flowHolder.mutableDeviceProximityFlow.asSharedFlow()
+            }
+
+        val genericNodeRequestFlow: SharedFlow<GenericNodeRequest>
+            get() {
+                return flowHolder.mutableGenericNodeRequestFlow.asSharedFlow()
             }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import inc.combustion.framework.LOG_TAG
+import inc.combustion.framework.ble.NetworkManager
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.ble.uart.meatnet.*
 import inc.combustion.framework.ble.uart.meatnet.NodeReadFeatureFlagsRequest
@@ -30,7 +31,7 @@ internal class NodeBleDevice(
     }
 
     init {
-        processUartResponses()
+        processUartMessages()
     }
 
     val rssi: Int get() { return uart.rssi }
@@ -77,31 +78,37 @@ internal class NodeBleDevice(
         }
     }
 
-    private fun observeUartResponses(callback: (suspend (responses: List<NodeUARTMessage>) -> Unit)? = null) {
+    private fun observeUartMessages(callback: (suspend (messages: List<NodeUARTMessage>) -> Unit)? = null) {
         uart.jobManager.addJob(
             key = uart.serialNumber,
             job = uart.owner.lifecycleScope.launch(
                 CoroutineName("UartResponseObserver"),
             ) {
                 uart.observeUartCharacteristic {data ->
-                    val responses = NodeUARTMessage.fromData(data.toUByteArray())
-                    callback?.invoke(responses)
+                    val messages = NodeUARTMessage.fromData(data.toUByteArray())
+                    callback?.invoke(messages)
                 }
             }
         )
     }
-    private fun processUartResponses() {
-        observeUartResponses { responses ->
-            responses.forEach { response ->
-                when (response) {
+    private fun processUartMessages() {
+        observeUartMessages { messages ->
+            messages.forEach { message ->
+                when (message) {
                     is NodeReadFeatureFlagsResponse -> {
-                        readFeatureFlagsRequest.handled(response.success, response, response.requestId)
+                        readFeatureFlagsRequest.handled(message.success, message, message.requestId)
                     }
                     is GenericNodeResponse -> {
-                        genericRequestHandler.handled(response.success, response, response.requestId)
-                    } else -> {
+                        genericRequestHandler.handled(message.success, message, message.requestId)
+                    }
+                    is GenericNodeRequest -> {
+                        // Publish the request to the flow so it can be handled by the user.
+                        // TODO: need to make sure that the request includes the node serial number
+                        NetworkManager.flowHolder.mutableGenericNodeRequestFlow.emit(message)
+                    }
+                    else -> {
                         // drop the message
-                        Log.w(LOG_TAG, "NodeBLEDevice: Unhandled response: $response")
+                        //Log.w(LOG_TAG, "NodeBLEDevice: Unhandled response: $response")
                     }
                 }
             }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -103,7 +103,7 @@ internal class NodeBleDevice(
                     }
                     is GenericNodeRequest -> {
                         // Publish the request to the flow so it can be handled by the user.
-                        // TODO: need to make sure that the request includes the node serial number
+                        message.serialNumber = deviceInfoSerialNumber?: ""
                         NetworkManager.flowHolder.mutableGenericNodeRequestFlow.emit(message)
                     }
                     else -> {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -103,7 +103,6 @@ internal class NodeBleDevice(
                     }
                     is GenericNodeRequest -> {
                         // Publish the request to the flow so it can be handled by the user.
-                        message.nodeSerialNumber = deviceInfoSerialNumber?: ""
                         NetworkManager.flowHolder.mutableGenericNodeRequestFlow.emit(message)
                     }
                     else -> {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -103,7 +103,7 @@ internal class NodeBleDevice(
                     }
                     is GenericNodeRequest -> {
                         // Publish the request to the flow so it can be handled by the user.
-                        message.serialNumber = deviceInfoSerialNumber?: ""
+                        message.nodeSerialNumber = deviceInfoSerialNumber?: ""
                         NetworkManager.flowHolder.mutableGenericNodeRequestFlow.emit(message)
                     }
                     else -> {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -78,15 +78,15 @@ internal class NodeBleDevice(
         }
     }
 
-    private fun observeUartMessages(callback: (suspend (messages: List<NodeUARTMessage>) -> Unit)? = null) {
+    private fun observeUartMessages(callback: (suspend (messages: List<NodeUARTMessage>) -> Unit)) {
         uart.jobManager.addJob(
             key = uart.serialNumber,
             job = uart.owner.lifecycleScope.launch(
                 CoroutineName("UartResponseObserver"),
             ) {
-                uart.observeUartCharacteristic {data ->
+                uart.observeUartCharacteristic { data ->
                     val messages = NodeUARTMessage.fromData(data.toUByteArray())
-                    callback?.invoke(messages)
+                    callback.invoke(messages)
                 }
             }
         )

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
@@ -3,11 +3,13 @@ package inc.combustion.framework.ble.uart.meatnet
 // wrapper around a NodeRequest to encrypt the data
 open class GenericNodeRequest(
     outgoingPayload: UByteArray,
-    messageId: NodeMessage)
-    : NodeUARTMessage(messageId, outgoingPayload.size.toUByte())
-{
+    messageId: NodeMessage,
+) : NodeUARTMessage(
+    messageId,
+    outgoingPayload.size.toUByte()
+) {
     override fun toString(): String {
-        return nodeRequest.toString()
+        return "${nodeRequest} SerialNumber: $serialNumber"
     }
 
     private val nodeRequest :  NodeRequest = NodeRequest(outgoingPayload, messageId)
@@ -15,6 +17,9 @@ open class GenericNodeRequest(
     internal fun toNodeRequest() : NodeRequest {
         return nodeRequest
     }
+
+    var serialNumber: String = ""
+
     val sData get() = nodeRequest.sData
 
     companion object {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
@@ -2,7 +2,7 @@ package inc.combustion.framework.ble.uart.meatnet
 
 // wrapper around a NodeRequest to encrypt the data
 open class GenericNodeRequest(
-    outgoingPayload: UByteArray,
+    val outgoingPayload: UByteArray,
     messageId: NodeMessage,
 ) : NodeUARTMessage(
     messageId,
@@ -23,6 +23,7 @@ open class GenericNodeRequest(
     val sData get() = nodeRequest.sData
 
     companion object {
+        const val HEADER_SIZE = NodeRequest.HEADER_SIZE
         fun fromRaw(
             data: UByteArray,
             requestId: UInt,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
@@ -1,7 +1,10 @@
 package inc.combustion.framework.ble.uart.meatnet
 
 // wrapper around a NodeRequest to encrypt the data
-open class GenericNodeRequest (outgoingPayload: UByteArray, messageId: NodeMessage)
+open class GenericNodeRequest(
+    outgoingPayload: UByteArray,
+    messageId: NodeMessage)
+    : NodeUARTMessage(messageId, outgoingPayload.size.toUByte())
 {
     override fun toString(): String {
         return nodeRequest.toString()
@@ -13,4 +16,18 @@ open class GenericNodeRequest (outgoingPayload: UByteArray, messageId: NodeMessa
         return nodeRequest
     }
     val sData get() = nodeRequest.sData
+
+    companion object {
+        fun fromRaw(
+            data: UByteArray,
+            requestId: UInt,
+            payloadLength: UByte,
+            messageId: NodeMessage
+            ): GenericNodeRequest {
+            return GenericNodeRequest(
+                data,
+                messageId
+            )
+        }
+    }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
@@ -1,15 +1,47 @@
 package inc.combustion.framework.ble.uart.meatnet
 
-// wrapper around a NodeRequest to encrypt the data
 open class GenericNodeRequest(
     val outgoingPayload: UByteArray,
+    var nodeSerialNumber: String,
+    val requestId: UInt?,
+    payloadLength: UByte,
     messageId: NodeMessage,
 ) : NodeUARTMessage(
     messageId,
     outgoingPayload.size.toUByte()
 ) {
+    /**
+     * Constructor for generating incoming requests without a serial number
+     */
+    constructor(
+        outgoingPayload: UByteArray,
+        requestId: UInt,
+        payloadLength: UByte,
+        messageId: NodeMessage
+    ) : this(
+        outgoingPayload,
+        "",
+        requestId,
+        payloadLength,
+        messageId
+    )
+
+    /**
+     * Constructor for generating outgoing requests
+     */
+    constructor(
+        outgoingPayload: UByteArray,
+        messageId: NodeMessage
+    ) : this(
+        outgoingPayload,
+        "",
+        null,
+        outgoingPayload.size.toUByte(),
+        messageId
+    )
+
     override fun toString(): String {
-        return "${nodeRequest} SerialNumber: $serialNumber"
+        return "${nodeRequest} SerialNumber: $nodeSerialNumber"
     }
 
     private val nodeRequest :  NodeRequest = NodeRequest(outgoingPayload, messageId)
@@ -18,12 +50,11 @@ open class GenericNodeRequest(
         return nodeRequest
     }
 
-    var serialNumber: String = ""
-
     val sData get() = nodeRequest.sData
 
     companion object {
         const val HEADER_SIZE = NodeRequest.HEADER_SIZE
+
         fun fromRaw(
             data: UByteArray,
             requestId: UInt,
@@ -32,6 +63,8 @@ open class GenericNodeRequest(
             ): GenericNodeRequest {
             return GenericNodeRequest(
                 data,
+                requestId,
+                payloadLength,
                 messageId
             )
         }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
@@ -11,22 +11,6 @@ open class GenericNodeRequest(
     outgoingPayload.size.toUByte()
 ) {
     /**
-     * Constructor for generating incoming requests without a serial number
-     */
-    constructor(
-        outgoingPayload: UByteArray,
-        requestId: UInt,
-        payloadLength: UByte,
-        messageId: NodeMessage
-    ) : this(
-        outgoingPayload,
-        "",
-        requestId,
-        payloadLength,
-        messageId
-    )
-
-    /**
      * Constructor for generating outgoing requests
      */
     constructor(
@@ -54,15 +38,27 @@ open class GenericNodeRequest(
 
     companion object {
         const val HEADER_SIZE = NodeRequest.HEADER_SIZE
+        private const val NODE_SERIAL_NUMBER_LENGTH = 10
 
         fun fromRaw(
             data: UByteArray,
             requestId: UInt,
             payloadLength: UByte,
             messageId: NodeMessage
-            ): GenericNodeRequest {
+            ): GenericNodeRequest? {
+
+            if (payloadLength < NODE_SERIAL_NUMBER_LENGTH.toUByte())
+                return null
+
+            val nodeSerialNumber = String(
+                data.copyOfRange(
+                    HEADER_SIZE.toInt(),
+                    HEADER_SIZE.toInt() + NODE_SERIAL_NUMBER_LENGTH
+                ).toByteArray(), Charsets.UTF_8
+            )
             return GenericNodeRequest(
                 data,
+                nodeSerialNumber,
                 requestId,
                 payloadLength,
                 messageId

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
@@ -71,7 +71,7 @@ internal open class NodeRequest(
             // Message type
             val rawMessageType = data[4]
 
-            val messageType = NodeMessageType.fromUByte(rawMessageType)// ?: null
+            val messageType = NodeMessageType.fromUByte(rawMessageType)
 
             // Request ID
             val requestId = data.getLittleEndianUInt32At(5)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -80,7 +80,7 @@ internal open class NodeResponse(
 
             val rawMessageType = typeRaw and RESPONSE_TYPE_FLAG.inv()
             val messageType = NodeMessageType.fromUByte(rawMessageType)
-                ?: rawMessageType
+                ?: null
 
             // Request ID
             val requestId = data.getLittleEndianUInt32At(5)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -80,7 +80,6 @@ internal open class NodeResponse(
 
             val rawMessageType = typeRaw and RESPONSE_TYPE_FLAG.inv()
             val messageType = NodeMessageType.fromUByte(rawMessageType)
-                ?: null
 
             // Request ID
             val requestId = data.getLittleEndianUInt32At(5)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -263,6 +263,14 @@ class DeviceManager(
         }
 
     /**
+     * Kotlin flow for collecting GenericNodeRequest messages that are sent from nodes.
+     */
+    val genericNodeRequestFlow : SharedFlow<GenericNodeRequest>
+        get() {
+            return NetworkManager.genericNodeRequestFlow
+        }
+
+    /**
      * Returns a list of device serial numbers, consisting of all devices that have been
      * discovered.
      */
@@ -271,6 +279,10 @@ class DeviceManager(
             return NetworkManager.instance.discoveredProbes
         }
 
+    /**
+     * Returns a list of node serial numbers, consisting of all nodes that have been discovered.
+     * This will exclude any probe devices.
+     */
     val discoveredNodes: List<String>
         get() {
             return NetworkManager.instance.discoveredNodes


### PR DESCRIPTION
Add support for sending generic requests to the user of the framework if they want to handle them.

This pull request introduces several changes to the `combustion-android-ble` project, mainly focusing on the handling of UART messages and the integration of `GenericNodeRequest` flows. The changes include updates to the `NetworkManager`, `NodeBleDevice`, and related classes to support the new flow and improve message handling.

### Enhancements to NetworkManager:

* Added `mutableGenericNodeRequestFlow` to `NetworkManager` to handle generic node requests. [[1]](diffhunk://#diff-6a03f0af2d3f3d2b783cd0040dad7026ecab95b2f14fe975fc856ed7f58021efR74) [[2]](diffhunk://#diff-6a03f0af2d3f3d2b783cd0040dad7026ecab95b2f14fe975fc856ed7f58021efR167-R169)
* Exposed `genericNodeRequestFlow` as a `SharedFlow` in `NetworkManager`.

### Updates to NodeBleDevice:

* Renamed methods from `processUartResponses` to `processUartMessages` and `observeUartResponses` to `observeUartMessages` for better clarity. [[1]](diffhunk://#diff-dd8bf65e39d432f0ae1489cdc0c0dd63cc822f08c9331beb7034894eba00aec1L33-R34) [[2]](diffhunk://#diff-dd8bf65e39d432f0ae1489cdc0c0dd63cc822f08c9331beb7034894eba00aec1L80-R111)
* Integrated `GenericNodeRequest` handling within the `processUartMessages` method.

### Modifications to UART Message Handling:

* Enhanced `GenericNodeRequest` class to include a `serialNumber` property and a companion object for creating instances from raw data.
* Updated `NodeRequest` to return `NodeUARTMessage` and handle custom message types using a callback. [[1]](diffhunk://#diff-f9bf9e230feee3c09355f846a951d9001bbfaf173b5d66b3504abd2ab8d24ad4L62-R63) [[2]](diffhunk://#diff-f9bf9e230feee3c09355f846a951d9001bbfaf173b5d66b3504abd2ab8d24ad4L119-R129)

### Additional Changes:

* Imported `NetworkManager` in `NodeBleDevice`.
* Added `genericNodeRequestFlow` to `DeviceManager` for collecting `GenericNodeRequest` messages.
* Documented discovered node functionality in `DeviceManager`.