### PR TITLE
DROID-516 - Prevent exception when CRC length isn't correct

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
@@ -85,6 +85,11 @@ internal open class NodeRequest(
             val crcDataLength = 6 + payloadLength.toInt()
 
             var crcData = data.drop(4).toUByteArray()
+            // Prevent index out of bounds or negative value
+            if (crcData.size < crcDataLength) {
+                Log.w(LOG_TAG, "Invalid crc data length")
+                return null
+            }
             crcData = crcData.dropLast(crcData.size - crcDataLength).toUByteArray()
 
             val calculatedCRC = crcData.getCRC16CCITT()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -27,6 +27,8 @@
  */
 package inc.combustion.framework.ble.uart.meatnet
 
+import android.util.Log
+import inc.combustion.framework.LOG_TAG
 import inc.combustion.framework.ble.getCRC16CCITT
 import inc.combustion.framework.ble.getLittleEndianUInt32At
 import inc.combustion.framework.ble.getLittleEndianUShortAt
@@ -99,6 +101,11 @@ internal open class NodeResponse(
             val crcDataLength = 11 + payloadLength.toInt()
 
             var crcData = data.drop(4).toUByteArray()
+            // prevent index out of bounds or negative value
+            if (crcData.size < crcDataLength) {
+                Log.w(LOG_TAG, "Invalid crc data length")
+                return null
+            }
             crcData = crcData.dropLast(crcData.size - crcDataLength).toUByteArray()
 
             val calculatedCRC = crcData.getCRC16CCITT()


### PR DESCRIPTION
If a response message fails the CRC check for some reason it will attempt to be parsed as a request message. This should also fail the CRC check though it is possible for the length to be incorrect since the payloadLength is stored in different locations. If this value becomes negative an exception will be thrown because its in invalid index. To prevent this from happening the framework now checks to ensure the crcData size is greater than or equal to the expected length.

This pull request includes changes to improve error handling and prevent index out of bounds errors in the `NodeRequest` and `NodeResponse` classes. Additionally, it includes necessary imports for logging.

Improvements to error handling:

* [`combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt`](diffhunk://#diff-f9bf9e230feee3c09355f846a951d9001bbfaf173b5d66b3504abd2ab8d24ad4R88-R92): Added a check to prevent index out of bounds or negative value for `crcData` size and log a warning if the condition is met.
* [`combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt`](diffhunk://#diff-ee48eef8ec257de5ca033335938a556f0f048ea29ae806b8edd16161466a42f0R104-R108): Added a check to prevent index out of bounds or negative value for `crcData` size and log a warning if the condition is met.

Additional imports for logging:

* [`combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt`](diffhunk://#diff-ee48eef8ec257de5ca033335938a556f0f048ea29ae806b8edd16161466a42f0R30-R31): Imported `Log` and `LOG_TAG` for logging purposes.
