### PR TITLE
Remove request header from payload data

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -137,11 +137,7 @@ internal class NetworkManager(
         }
 
         private fun removeDisconnectedNodes() {
-           connectedNodes.forEach() { (serialNumber, node) ->
-               if(node.isDisconnected) {
-                   connectedNodes.remove(serialNumber)
-               }
-           }
+            connectedNodes.entries.removeIf() { (_, node) -> node.isDisconnected }
         }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
@@ -8,7 +8,7 @@ open class GenericNodeRequest(
     messageId: NodeMessage,
 ) : NodeUARTMessage(
     messageId,
-    outgoingPayload.size.toUByte()
+    payloadLength
 ) {
     /**
      * Constructor for generating outgoing requests

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/GenericNodeRequest.kt
@@ -56,8 +56,12 @@ open class GenericNodeRequest(
                     HEADER_SIZE.toInt() + NODE_SERIAL_NUMBER_LENGTH
                 ).toByteArray(), Charsets.UTF_8
             )
+
+            // remove the header from the data since we want to just pass along the payload
+            val payloadData = data.copyOfRange(HEADER_SIZE.toInt(), data.size)
+
             return GenericNodeRequest(
-                data,
+                payloadData,
                 nodeSerialNumber,
                 requestId,
                 payloadLength,


### PR DESCRIPTION
The GenericRequest wasn't removing the request header from the payload data and passing that along. That resulted in the size of the payload being incorrect potentially causing an out of bounds exception.
