### PR TITLE
Increase wifi timeouts and make sendNodeRequest call threadsafe

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -96,7 +96,7 @@ internal class NetworkManager(
         ) {
             connectedNodes[deviceId]?.let {
                 val mutex = getNodeRequestMutex(deviceId)
-                // TODO : initial sendNodeRequest threadsafety solution - should be replaced with a better solution,
+                // TODO DROID-531 : initial sendNodeRequest threadsafety solution - should be replaced with a better solution,
                 //  e.g. one that is coroutine-suspend friendly (instead of thread-block)
                 mutex.acquire()
                 it.sendNodeRequest(request) { status, data ->

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -84,6 +84,7 @@ internal class NetworkManager(
         private val nodeRequestMutexMap: MutableMap<String, Semaphore> = ConcurrentHashMap()
 
         private fun getNodeRequestMutex(deviceId: String): Semaphore =
+            // Note, using Java's Semaphore instead ok Kotlin's coroutine friendly version since methods do not use suspend modifier
             nodeRequestMutexMap[deviceId] ?: (Semaphore(1, true).also {
                 nodeRequestMutexMap[deviceId] = it
             })
@@ -95,6 +96,8 @@ internal class NetworkManager(
         ) {
             connectedNodes[deviceId]?.let {
                 val mutex = getNodeRequestMutex(deviceId)
+                // TODO : initial sendNodeRequest threadsafety solution - should be replaced with a better solution,
+                //  e.g. one that is coroutine-suspend friendly (instead of thread-block)
                 mutex.acquire()
                 it.sendNodeRequest(request) { status, data ->
                     mutex.release()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -7,8 +7,12 @@ import androidx.lifecycle.lifecycleScope
 import inc.combustion.framework.LOG_TAG
 import inc.combustion.framework.ble.NetworkManager
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
-import inc.combustion.framework.ble.uart.meatnet.*
+import inc.combustion.framework.ble.uart.meatnet.GenericNodeRequest
+import inc.combustion.framework.ble.uart.meatnet.GenericNodeResponse
 import inc.combustion.framework.ble.uart.meatnet.NodeReadFeatureFlagsRequest
+import inc.combustion.framework.ble.uart.meatnet.NodeReadFeatureFlagsResponse
+import inc.combustion.framework.ble.uart.meatnet.NodeRequest
+import inc.combustion.framework.ble.uart.meatnet.NodeUARTMessage
 import inc.combustion.framework.service.DebugSettings
 import inc.combustion.framework.service.DeviceConnectionState
 import kotlinx.coroutines.CoroutineName
@@ -23,8 +27,8 @@ internal class NodeBleDevice(
     private var uart: UartBleDevice = UartBleDevice(mac, nodeAdvertisingData, owner, adapter)
 ) {
 
-    protected val genericRequestHandler = UartBleDevice.MessageCompletionHandler()
-    protected val readFeatureFlagsRequest = UartBleDevice.MessageCompletionHandler()
+    private val genericRequestHandler = UartBleDevice.MessageCompletionHandler()
+    private val readFeatureFlagsRequest = UartBleDevice.MessageCompletionHandler()
 
     companion object {
         const val NODE_MESSAGE_RESPONSE_TIMEOUT_MS = 30000L
@@ -34,25 +38,51 @@ internal class NodeBleDevice(
         processUartMessages()
     }
 
-    val rssi: Int get() { return uart.rssi }
-    val connectionState: DeviceConnectionState get() { return uart.connectionState }
-    val isConnected: Boolean get() { return uart.isConnected.get() }
-    val isDisconnected: Boolean get() { return uart.isDisconnected.get() }
-    val isInRange: Boolean get() { return uart.isInRange.get() }
-    val isConnectable: Boolean get() { return uart.isConnectable.get() }
+    val rssi: Int
+        get() {
+            return uart.rssi
+        }
+    val connectionState: DeviceConnectionState
+        get() {
+            return uart.connectionState
+        }
+    val isConnected: Boolean
+        get() {
+            return uart.isConnected.get()
+        }
+    val isDisconnected: Boolean
+        get() {
+            return uart.isDisconnected.get()
+        }
+    val isInRange: Boolean
+        get() {
+            return uart.isInRange.get()
+        }
+    val isConnectable: Boolean
+        get() {
+            return uart.isConnectable.get()
+        }
 
-    val deviceInfoSerialNumber: String? get() { return uart.serialNumber }
+    val deviceInfoSerialNumber: String?
+        get() {
+            return uart.serialNumber
+        }
 
     @Synchronized
     fun sendNodeRequest(request: GenericNodeRequest, callback: ((Boolean, Any?) -> Unit)?) {
         val nodeRequest = request.toNodeRequest()
-        genericRequestHandler.wait(uart.owner, NODE_MESSAGE_RESPONSE_TIMEOUT_MS, nodeRequest.requestId, callback)
+        genericRequestHandler.wait(
+            uart.owner,
+            NODE_MESSAGE_RESPONSE_TIMEOUT_MS,
+            nodeRequest.requestId,
+            callback
+        )
         sendUartRequest(nodeRequest)
     }
 
     @Synchronized
     fun sendFeatureFlagRequest(reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
-        val nodeSerialNumber = deviceInfoSerialNumber?: return
+        val nodeSerialNumber = deviceInfoSerialNumber ?: return
         readFeatureFlagsRequest.wait(uart.owner, NODE_MESSAGE_RESPONSE_TIMEOUT_MS, reqId, callback)
         sendUartRequest(NodeReadFeatureFlagsRequest(nodeSerialNumber, reqId))
     }
@@ -93,6 +123,7 @@ internal class NodeBleDevice(
             }
         )
     }
+
     private fun processUartMessages() {
         observeUartMessages { messages ->
             messages.forEach { message ->
@@ -100,13 +131,16 @@ internal class NodeBleDevice(
                     is NodeReadFeatureFlagsResponse -> {
                         readFeatureFlagsRequest.handled(message.success, message, message.requestId)
                     }
+
                     is GenericNodeResponse -> {
                         genericRequestHandler.handled(message.success, message, message.requestId)
                     }
+
                     is GenericNodeRequest -> {
                         // Publish the request to the flow so it can be handled by the user.
                         NetworkManager.flowHolder.mutableGenericNodeRequestFlow.emit(message)
                     }
+
                     else -> {
                         // drop the message
                         //Log.w(LOG_TAG, "NodeBLEDevice: Unhandled response: $response")

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -27,7 +27,7 @@ internal class NodeBleDevice(
     protected val readFeatureFlagsRequest = UartBleDevice.MessageCompletionHandler()
 
     companion object {
-        const val NODE_MESSAGE_RESPONSE_TIMEOUT_MS = 5000L
+        const val NODE_MESSAGE_RESPONSE_TIMEOUT_MS = 30000L
     }
 
     init {
@@ -43,12 +43,14 @@ internal class NodeBleDevice(
 
     val deviceInfoSerialNumber: String? get() { return uart.serialNumber }
 
+    @Synchronized
     fun sendNodeRequest(request: GenericNodeRequest, callback: ((Boolean, Any?) -> Unit)?) {
         val nodeRequest = request.toNodeRequest()
         genericRequestHandler.wait(uart.owner, NODE_MESSAGE_RESPONSE_TIMEOUT_MS, nodeRequest.requestId, callback)
         sendUartRequest(nodeRequest)
     }
 
+    @Synchronized
     fun sendFeatureFlagRequest(reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
         val nodeSerialNumber = deviceInfoSerialNumber?: return
         readFeatureFlagsRequest.wait(uart.owner, NODE_MESSAGE_RESPONSE_TIMEOUT_MS, reqId, callback)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -68,7 +68,6 @@ internal class NodeBleDevice(
             return uart.serialNumber
         }
 
-    @Synchronized
     fun sendNodeRequest(request: GenericNodeRequest, callback: ((Boolean, Any?) -> Unit)?) {
         val nodeRequest = request.toNodeRequest()
         genericRequestHandler.wait(
@@ -80,7 +79,6 @@ internal class NodeBleDevice(
         sendUartRequest(nodeRequest)
     }
 
-    @Synchronized
     fun sendFeatureFlagRequest(reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
         val nodeSerialNumber = deviceInfoSerialNumber ?: return
         readFeatureFlagsRequest.wait(uart.owner, NODE_MESSAGE_RESPONSE_TIMEOUT_MS, reqId, callback)


### PR DESCRIPTION
https://linear.app/combustion/issue/DROID-530/wifi-connect-times-out
https://linear.app/combustion/issue/DROID-531/synchronize-wifi-calls-to-ble-device

## Description
- Wifi related calls are timing out
- `NodeBleDevice..sendNodeRequest()` calls are not threadsafe - observed calls getting stuck callback never happening

**Note, first commit is easier to read since does not contain autoformatting**

## Tech Notes
- increase timeout to 30000millis (30s) since WIFI_CONNECT call still timeouts at 15s and fast calls will finish fast anyway
- `Semaphore`s used in `NetworkManager` to ensure a single node request at a time per node.