### PR TITLE
DROID-520: Added handling of async NodeResponse messages

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -71,7 +71,7 @@ internal class NetworkManager(
         var mutableNetworkState: MutableStateFlow<NetworkState>,
         var mutableFirmwareUpdateState: MutableStateFlow<FirmwareState>,
         var mutableDeviceProximityFlow: MutableSharedFlow<DeviceDiscoveredEvent>,
-        var mutableGenericNodeRequestFlow: MutableSharedFlow<GenericNodeRequest>,
+        var mutableGenericNodeMessageFlow: MutableSharedFlow<NodeUARTMessage>,
     )
 
     inner private class NodeDeviceManager(
@@ -161,7 +161,7 @@ internal class NetworkManager(
             mutableDeviceProximityFlow = MutableSharedFlow(
                 FLOW_CONFIG_REPLAY, FLOW_CONFIG_BUFFER, BufferOverflow.SUSPEND
             ),
-            mutableGenericNodeRequestFlow = MutableSharedFlow(
+            mutableGenericNodeMessageFlow = MutableSharedFlow(
                 FLOW_CONFIG_NO_REPLAY, FLOW_CONFIG_BUFFER, BufferOverflow.DROP_OLDEST
             ),
         )
@@ -214,9 +214,9 @@ internal class NetworkManager(
                 return flowHolder.mutableDeviceProximityFlow.asSharedFlow()
             }
 
-        val genericNodeRequestFlow: SharedFlow<GenericNodeRequest>
+        val genericNodeMessageFlow: SharedFlow<NodeUARTMessage>
             get() {
-                return flowHolder.mutableGenericNodeRequestFlow.asSharedFlow()
+                return flowHolder.mutableGenericNodeMessageFlow.asSharedFlow()
             }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
@@ -63,13 +63,16 @@ internal open class UartBleDevice(
                 return waiting.get()
             }
 
-        fun handled(result: Boolean, data: Any?, reqId: UInt? = null) {
+        // Returns true if the message was handled, false otherwise
+        // If the message was handled, the completion callback is called
+        // with the result and data
+        fun handled(result: Boolean, data: Any?, reqId: UInt? = null): Boolean {
             // if we are waiting for a specific request id
             requestId?.let {
                 // and we weren't called with the request id we are looking for
                 if(it != reqId) {
                     // then return
-                    return
+                    return false
                 }
             }
 
@@ -82,7 +85,10 @@ internal open class UartBleDevice(
 
             localCallback?.let {
                 it(result, data)
+                return true
             }
+
+            return false
         }
 
         fun wait(owner: LifecycleOwner, duration: Long, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)?) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt
@@ -63,16 +63,16 @@ internal open class UartBleDevice(
                 return waiting.get()
             }
 
-        // Returns true if the message was handled, false otherwise
-        // If the message was handled, the completion callback is called
-        // with the result and data
+        // Returns true if the message reqId matched or the callback was called
         fun handled(result: Boolean, data: Any?, reqId: UInt? = null): Boolean {
+            var matched = false
             // if we are waiting for a specific request id
             requestId?.let {
                 // and we weren't called with the request id we are looking for
-                if(it != reqId) {
-                    // then return
-                    return false
+                if(it == reqId) {
+                    matched = true
+                } else {
+                    return matched
                 }
             }
 
@@ -85,10 +85,10 @@ internal open class UartBleDevice(
 
             localCallback?.let {
                 it(result, data)
-                return true
+                matched = true
             }
 
-            return false
+            return matched
         }
 
         fun wait(owner: LifecycleOwner, duration: Long, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)?) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -44,6 +44,7 @@ import inc.combustion.framework.ble.dfu.DfuManager
 import inc.combustion.framework.ble.uart.meatnet.GenericNodeRequest
 import inc.combustion.framework.ble.uart.meatnet.GenericNodeResponse
 import inc.combustion.framework.ble.uart.meatnet.NodeMessage
+import inc.combustion.framework.ble.uart.meatnet.NodeUARTMessage
 import inc.combustion.framework.service.dfu.DfuSystemState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
@@ -265,9 +266,9 @@ class DeviceManager(
     /**
      * Kotlin flow for collecting GenericNodeRequest messages that are sent from nodes.
      */
-    val genericNodeRequestFlow : SharedFlow<GenericNodeRequest>
+    val genericNodeRequestFlow : SharedFlow<NodeUARTMessage>
         get() {
-            return NetworkManager.genericNodeRequestFlow
+            return NetworkManager.genericNodeMessageFlow
         }
 
     /**


### PR DESCRIPTION
* Updated NodeBLeDevice to pass async GenericNodeResponse messages to the NetworkManager. 
* Updated some methods and type names to be more generic since both requests and response are now being handled.

### Refactoring and Renaming Flows:

* [`combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt`](diffhunk://#diff-6a03f0af2d3f3d2b783cd0040dad7026ecab95b2f14fe975fc856ed7f58021efL74-R74): Renamed `mutableGenericNodeRequestFlow` to `mutableGenericNodeMessageFlow` and updated its type from `GenericNodeRequest` to `NodeUARTMessage`. This change was applied to both the variable declaration and initialization. [[1]](diffhunk://#diff-6a03f0af2d3f3d2b783cd0040dad7026ecab95b2f14fe975fc856ed7f58021efL74-R74) [[2]](diffhunk://#diff-6a03f0af2d3f3d2b783cd0040dad7026ecab95b2f14fe975fc856ed7f58021efL164-R164) [[3]](diffhunk://#diff-6a03f0af2d3f3d2b783cd0040dad7026ecab95b2f14fe975fc856ed7f58021efL217-R219)

### Enhancements to Message Handling:

* [`combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt`](diffhunk://#diff-dd8bf65e39d432f0ae1489cdc0c0dd63cc822f08c9331beb7034894eba00aec1L102-R111): Updated the handling of `GenericNodeResponse` and `GenericNodeRequest` messages to use the renamed `mutableGenericNodeMessageFlow`. Added a log and conditional handling to pass unhandled `GenericNodeResponse` messages up to the `NetworkManager`.

### Improvements to Method Return Values:

* [`combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartBleDevice.kt`](diffhunk://#diff-28698900a4fb8eb3d30650caf30c5b5f0c02f6aeb3e4a1fe2a98d7245ba30589L66-R75): Modified the `handled` method to return a boolean indicating whether the message was handled. This change helps in determining if the message should be passed up to the `NetworkManager`. [[1]](diffhunk://#diff-28698900a4fb8eb3d30650caf30c5b5f0c02f6aeb3e4a1fe2a98d7245ba30589L66-R75) [[2]](diffhunk://#diff-28698900a4fb8eb3d30650caf30c5b5f0c02f6aeb3e4a1fe2a98d7245ba30589R88-R91)

### Import Adjustments:

* [`combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt`](diffhunk://#diff-edfbd9a24b6e05666e9a4cc19fba2394d137c98276b81e80b4ac7cc3df5bb46bR47): Added import for `NodeUARTMessage` and updated the `genericNodeRequestFlow` property to return `NetworkManager.genericNodeMessageFlow` instead. [[1]](diffhunk://#diff-edfbd9a24b6e05666e9a4cc19fba2394d137c98276b81e80b4ac7cc3df5bb46bR47) [[2]](diffhunk://#diff-edfbd9a24b6e05666e9a4cc19fba2394d137c98276b81e80b4ac7cc3df5bb46bL268-R271)