### PR TITLE
DROID-538 : increase bt response timeout for wifi comms to 120s

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -31,7 +31,7 @@ internal class NodeBleDevice(
     private val readFeatureFlagsRequest = UartBleDevice.MessageCompletionHandler()
 
     companion object {
-        const val NODE_MESSAGE_RESPONSE_TIMEOUT_MS = 30000L
+        const val NODE_MESSAGE_RESPONSE_TIMEOUT_MS = 120000L
     }
 
     init {


### PR DESCRIPTION
## Desctiption 
it was requested to increase the timeout since the firmware has a timeout of 90s and are thinking of increasing it to 120s