### PR TITLE
DROID-541: prevent ConcurrentModificationException when iterate over rssiCallbacks in BleDevice

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/BleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/BleDevice.kt
@@ -321,7 +321,7 @@ internal open class BleDevice (
             else -> DeviceConnectionState.ADVERTISING_NOT_CONNECTABLE
         }
 
-        rssiCallbacks.forEach {
+        rssiCallbacks.toList().forEach {
             dispatchOnDefault {
                 it(remoteRssi.get())
             }


### PR DESCRIPTION
https://linear.app/combustion/issue/DROID-541/app-crashes-when-there-are-many-probes-running

## Desctiption 
Prevent `ConcurrentModificationException` when iterate over `rssiCallbacks` in `BleDevice`

## Tech Notes
- do `rssiCallbacks.toList()`to  create an immutable copy for safe iteration.