### PR TITLE
DROID-560 - Fix overheating sensor flags forwareded from a node

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeStatus.kt
@@ -67,8 +67,8 @@ internal data class ProbeStatus(
 
     companion object {
         const val MIN_RAW_SIZE = 30
-        const val RAW_SIZE_INCLUDING_FOOD_SAFE_AND_OVERHEAT =
-            MIN_RAW_SIZE + FoodSafeData.SIZE_BYTES + FoodSafeStatus.SIZE_BYTES + OverheatingSensors.SIZE_BYTES
+        const val RAW_SIZE_INCLUDING_FOOD_SAFE =
+            MIN_RAW_SIZE + FoodSafeData.SIZE_BYTES + FoodSafeStatus.SIZE_BYTES
 
         private const val MIN_SEQ_INDEX = 0
         private const val MAX_SEQ_INDEX = 4
@@ -105,7 +105,7 @@ internal data class ProbeStatus(
             val batteryStatus = ProbeBatteryStatus.fromUByte(deviceStatus)
             val virtualSensors = ProbeVirtualSensors.fromDeviceStatus(deviceStatus)
 
-            val dataIncludesFoodSafe = data.size > MIN_RAW_SIZE
+            val dataIncludesFoodSafe = data.size > FOOD_SAFE_DATA_RANGE.last
             val foodSafeData = if (dataIncludesFoodSafe) {
                 FoodSafeData.fromRawData(data.sliceArray(FOOD_SAFE_DATA_RANGE))
             } else {
@@ -118,7 +118,7 @@ internal data class ProbeStatus(
             }
 
             // Decode Over heating flags
-            val dataIncludesOverheat = data.size >= overheatRange.last
+            val dataIncludesOverheat = data.size > overheatRange.last
             val overheatingSensors = if (dataIncludesOverheat) {
 
                 // Sanity check for the overheating flags. If none of the temperatures are above the

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeStatus.kt
@@ -69,8 +69,6 @@ internal data class ProbeStatus(
         const val MIN_RAW_SIZE = 30
         const val RAW_SIZE_INCLUDING_FOOD_SAFE =
             MIN_RAW_SIZE + FoodSafeData.SIZE_BYTES + FoodSafeStatus.SIZE_BYTES
-        const val RAW_SIZE_INCLUDING_OVERHEAT =
-            MIN_RAW_SIZE + FoodSafeData.SIZE_BYTES + FoodSafeStatus.SIZE_BYTES + OverheatingSensors.SIZE_BYTES
 
         private const val MIN_SEQ_INDEX = 0
         private const val MAX_SEQ_INDEX = 4
@@ -91,7 +89,7 @@ internal data class ProbeStatus(
         private val OVERHEAT_BYTE_RANGE =
             OVERHEAT_BYTE_START_INDEX until OVERHEAT_BYTE_START_INDEX + OverheatingSensors.SIZE_BYTES
 
-        fun fromRawData(data: UByteArray): ProbeStatus? {
+        fun fromRawData(data: UByteArray, overheatRange: IntRange = OVERHEAT_BYTE_RANGE): ProbeStatus? {
             if (data.size < MIN_RAW_SIZE) return null
 
             val minSequenceNumber = data.getLittleEndianUInt32At(MIN_SEQ_INDEX)
@@ -120,9 +118,9 @@ internal data class ProbeStatus(
             }
 
             // Decode Over heating flags
-            val dataIncludesOverheat = data.size >= RAW_SIZE_INCLUDING_OVERHEAT
+            val dataIncludesOverheat = data.size >= overheatRange.last
             val overheatingSensors = if (dataIncludesOverheat) {
-                OverheatingSensors.fromRawByte(data.sliceArray(OVERHEAT_BYTE_RANGE)[0])
+                OverheatingSensors.fromRawByte(data.sliceArray(overheatRange)[0])
             } else {
                 OverheatingSensors.fromTemperatures(temperatures)
             }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeStatus.kt
@@ -126,9 +126,9 @@ internal data class ProbeStatus(
                 // There is a bug in the repeater firmware versions <= 2.2.0 that can cause these
                 // flags to be incorrectly set. This should help reduce invalid overheating errors
                 // to the user.
-                if (!OverheatingSensors.fromTemperatures(temperatures).isAnySensorOverheating())
+                if (!OverheatingSensors.fromTemperatures(temperatures).isAnySensorOverheating()) {
                     OverheatingSensors.fromRawByte(0u)
-                else {
+                } else {
                     OverheatingSensors.fromRawByte(data.sliceArray(overheatRange)[0])
                 }
             } else {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
@@ -65,14 +65,15 @@ internal class NodeProbeStatusRequest(
             val probeStatusIndexEnd = PROBE_STATUS_INDEX + if (payloadLength.toInt() == MINIMUM_PAYLOAD_LENGTH) {
                     ProbeStatus.MIN_RAW_SIZE
                 } else {
-                    ProbeStatus.RAW_SIZE_INCLUDING_FOOD_SAFE
+                    // Add one byte because the overheating flags are after the hopcount :sad:
+                    ProbeStatus.RAW_SIZE_INCLUDING_FOOD_SAFE_AND_OVERHEAT + 1
                 }
 
             val probeStatusRange = PROBE_STATUS_INDEX until probeStatusIndexEnd
 
             // The overheating flags are stored after the hop count for the node messages
-            val overheatRangeStart = probeStatusIndexEnd + 1
-            val overheatRange = overheatRangeStart until probeStatusIndexEnd + OverheatingSensors.SIZE_BYTES
+            val overheatRangeStart = probeStatusIndexEnd - OverheatingSensors.SIZE_BYTES
+            val overheatRange = overheatRangeStart until probeStatusIndexEnd
 
             val probeStatus: ProbeStatus =
                 ProbeStatus.fromRawData(data.slice(probeStatusRange).toUByteArray(), overheatRange) ?: return null

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
@@ -65,15 +65,15 @@ internal class NodeProbeStatusRequest(
             val probeStatusIndexEnd = PROBE_STATUS_INDEX + if (payloadLength.toInt() == MINIMUM_PAYLOAD_LENGTH) {
                     ProbeStatus.MIN_RAW_SIZE
                 } else {
-                    // Add one byte because the overheating flags are after the hopcount :sad:
-                    ProbeStatus.RAW_SIZE_INCLUDING_FOOD_SAFE_AND_OVERHEAT + 1
+                    ProbeStatus.RAW_SIZE_INCLUDING_FOOD_SAFE
                 }
 
-            val probeStatusRange = PROBE_STATUS_INDEX until probeStatusIndexEnd
+            val probeStatusRange = PROBE_STATUS_INDEX until data.size
 
             // The overheating flags are stored after the hop count for the node messages
-            val overheatRangeStart = probeStatusIndexEnd - OverheatingSensors.SIZE_BYTES
-            val overheatRange = overheatRangeStart until probeStatusIndexEnd
+            // so the range is updated to take that into account
+            val overheatRangeStart = ProbeStatus.RAW_SIZE_INCLUDING_FOOD_SAFE + 1
+            val overheatRange = overheatRangeStart until overheatRangeStart + OverheatingSensors.SIZE_BYTES
 
             val probeStatus: ProbeStatus =
                 ProbeStatus.fromRawData(data.slice(probeStatusRange).toUByteArray(), overheatRange) ?: return null

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeProbeStatusRequest.kt
@@ -31,6 +31,7 @@ package inc.combustion.framework.ble.uart.meatnet
 import inc.combustion.framework.ble.ProbeStatus
 import inc.combustion.framework.ble.getLittleEndianUInt32At
 import inc.combustion.framework.service.HopCount
+import inc.combustion.framework.service.OverheatingSensors
 
 internal class NodeProbeStatusRequest(
     requestId : UInt,
@@ -69,8 +70,12 @@ internal class NodeProbeStatusRequest(
 
             val probeStatusRange = PROBE_STATUS_INDEX until probeStatusIndexEnd
 
+            // The overheating flags are stored after the hop count for the node messages
+            val overheatRangeStart = probeStatusIndexEnd + 1
+            val overheatRange = overheatRangeStart until probeStatusIndexEnd + OverheatingSensors.SIZE_BYTES
+
             val probeStatus: ProbeStatus =
-                ProbeStatus.fromRawData(data.slice(probeStatusRange).toUByteArray()) ?: return null
+                ProbeStatus.fromRawData(data.slice(probeStatusRange).toUByteArray(), overheatRange) ?: return null
 
             val hopCount: HopCount = HopCount.fromUByte(data[probeStatusIndexEnd])
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/OverheatingSensors.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/OverheatingSensors.kt
@@ -30,6 +30,10 @@ package inc.combustion.framework.service
 
 data class OverheatingSensors(val values: List<Int>) {
 
+    public fun isAnySensorOverheating: Boolean {
+        return values.isNotEmpty()
+    }
+
     companion object {
         internal const val SIZE_BYTES = 1
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/OverheatingSensors.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/OverheatingSensors.kt
@@ -30,7 +30,7 @@ package inc.combustion.framework.service
 
 data class OverheatingSensors(val values: List<Int>) {
 
-    public fun isAnySensorOverheating: Boolean {
+    public fun isAnySensorOverheating(): Boolean {
         return values.isNotEmpty()
     }
 


### PR DESCRIPTION
Update to correctly handle the location of the overheating flags when the probe status is forwarded by the node. They are actually past the `hopCount` so the range used for those flags needs to be updated.

Related iOS PRs - [PR-114](https://github.com/combustion-inc/combustion-ios-ble/pull/114) and [PR-115](https://github.com/combustion-inc/combustion-ios-ble/pull/115)