### PR TITLE
DROID-552 : WiFi devices appear even if not linked to a probe

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -634,7 +634,7 @@ internal class NetworkManager(
                 serialNumber = probeSerialNumber,
                 owner = owner,
                 settings = settings,
-                // called by the ProbeManager whenever a meatnet node is disconnected
+                // called by the ProbeManager whenever a MeatNet node is disconnected
                 dfuDisconnectedNodeCallback = {
                     firmwareStateOfNetwork.remove(it)
 
@@ -658,6 +658,9 @@ internal class NetworkManager(
         createProbeManagerIfNew(REPEATER_NO_PROBES_SERIAL_NUMBER)
     }
 
+    /**
+     * if we haven't seen link [linkId] before, then create it and add it to the right probe manager
+     */
     private fun createMeatNetLinkIfNewAndAddToProbeManager(
         linkId: LinkID,
         deviceId: String,


### PR DESCRIPTION
## Description
Show WiFi devices even when not linked to a probe

## Tech Notes
Solution is pretty basic and creates a dummy `ProbeManager` that manages all devices not connected to a probe.

in `NetworkManager`:
- instead of ignoring advertisements for devices with no probe (`serialNumber == REPEATER_NO_PROBES_SERIAL_NUMBER`), now add method `manageMeatNetDeviceWithProbe()` to support it
- renamed previous method to `manageMeatNetDeviceWithProbe()`

## Video
### WiFi Display visible with no probe connected
https://github.com/user-attachments/assets/078dbb8c-10da-4c07-bd5b-a6587a8dde41

