### PR TITLE
DROID-595 : rename power mode related classes to match cloud requirements

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -54,11 +54,11 @@ import inc.combustion.framework.service.ProbeID
 import inc.combustion.framework.service.ProbeMode
 import inc.combustion.framework.service.ProbePowerMode
 import inc.combustion.framework.service.ProbePredictionMode
-import inc.combustion.framework.service.ProbePreferences
 import inc.combustion.framework.service.ProbeTemperatures
 import inc.combustion.framework.service.ProbeUploadState
 import inc.combustion.framework.service.ProbeVirtualSensors
 import inc.combustion.framework.service.SessionInformation
+import inc.combustion.framework.service.ThermometerPreferences
 import inc.combustion.framework.service.utils.DefaultLinearizationTimerImpl
 import inc.combustion.framework.service.utils.PredictionManager
 import kotlinx.coroutines.CoroutineName
@@ -559,9 +559,12 @@ internal class ProbeManager(
     fun setPowerMode(powerMode: ProbePowerMode, completionHandler: (Boolean) -> Unit) {
         val onCompletion: (Boolean) -> Unit = { success ->
             if (success) {
+                val probeVal = _probe.value
                 _probe.update {
-                    _probe.value.copy(
-                        powerMode = powerMode,
+                    probeVal.copy(
+                        thermometerPrefs = probeVal.thermometerPrefs?.copy(
+                            powerMode = powerMode,
+                        ) ?: ThermometerPreferences(powerMode = powerMode),
                     )
                 }
             }
@@ -745,7 +748,7 @@ internal class ProbeManager(
                 status.maxSequenceNumber,
                 updatedProbe
             )
-            updatedProbe = updateProbePreferences(status.probePreferences, updatedProbe)
+            updatedProbe = updateThermometerPreferences(status.thermometerPrefs, updatedProbe)
 
             if (status.mode == ProbeMode.NORMAL) {
                 updatedProbe = updateNormalMode(status, updatedProbe)
@@ -1224,12 +1227,12 @@ internal class ProbeManager(
         )
     }
 
-    private fun updateProbePreferences(
-        probePreferences: ProbePreferences,
+    private fun updateThermometerPreferences(
+        thermometerPrefs: ThermometerPreferences,
         currentProbe: Probe,
     ): Probe {
         return currentProbe.copy(
-            powerMode = probePreferences.powerMode,
+            thermometerPrefs = thermometerPrefs,
         )
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeStatus.kt
@@ -49,7 +49,7 @@ internal data class ProbeStatus(
     val foodSafeData: FoodSafeData?,
     val foodSafeStatus: FoodSafeStatus?,
     val overheatingSensors: OverheatingSensors,
-    val probePreferences: ProbePreferences,
+    val thermometerPrefs: ThermometerPreferences,
 ) {
     val virtualCoreTemperature: Double
         get() {
@@ -140,12 +140,12 @@ internal data class ProbeStatus(
             }
 
             val probeRefsByteStartIndex = overheatRange.last + 1
-            val probeRefsRange = probeRefsByteStartIndex until probeRefsByteStartIndex + ProbePreferences.PROBE_PREFS_SIZE_BYTES
+            val probeRefsRange = probeRefsByteStartIndex until probeRefsByteStartIndex + ThermometerPreferences.PROBE_PREFS_SIZE_BYTES
             val probePrefs = if (data.size > probeRefsRange.last) {
                 val probePrefsRaw = data.sliceArray(probeRefsRange)[0]
-                ProbePreferences.fromUByte(probePrefsRaw)
+                ThermometerPreferences.fromUByte(probePrefsRaw)
             } else {
-                ProbePreferences.DEFAULT
+                ThermometerPreferences.DEFAULT
             }
 
             return ProbeStatus(
@@ -161,7 +161,7 @@ internal data class ProbeStatus(
                 foodSafeData = foodSafeData,
                 foodSafeStatus = foodSafeStatus,
                 overheatingSensors = overheatingSensors,
-                probePreferences = probePrefs,
+                thermometerPrefs = probePrefs,
             )
         }
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
@@ -182,7 +182,7 @@ internal class SimulatedProbeBleDevice(
                                 overheatingSensors = OverheatingSensors.fromTemperatures(
                                     probeTemperatures
                                 ),
-                                probePreferences = ProbePreferences.DEFAULT,
+                                thermometerPrefs = ThermometerPreferences.DEFAULT,
                             ),
                             null,
                         )

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
@@ -117,7 +117,7 @@ data class Probe(
     val logUploadPercent: UInt = 0u,
     val foodSafeData: FoodSafeData? = null,
     val foodSafeStatus: FoodSafeStatus? = null,
-    val powerMode: ProbePowerMode? = null,
+    val thermometerPrefs: ThermometerPreferences? = null,
 ) {
     val serialNumber = baseDevice.serialNumber
     val mac = baseDevice.mac

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ThermometerPreferences.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ThermometerPreferences.kt
@@ -28,15 +28,15 @@
 
 package inc.combustion.framework.service
 
-data class ProbePreferences(val powerMode: ProbePowerMode) {
+data class ThermometerPreferences(val powerMode: ProbePowerMode) {
 
     companion object {
         const val PROBE_PREFS_SIZE_BYTES = 1
 
-        val DEFAULT = ProbePreferences(powerMode = ProbePowerMode.NORMAL)
+        val DEFAULT = ThermometerPreferences(powerMode = ProbePowerMode.NORMAL)
 
-        fun fromUByte(byte: UByte): ProbePreferences {
-            return ProbePreferences(powerMode = ProbePowerMode.fromUByte(byte))
+        fun fromUByte(byte: UByte): ThermometerPreferences {
+            return ThermometerPreferences(powerMode = ProbePowerMode.fromUByte(byte))
         }
     }
 }


### PR DESCRIPTION
https://linear.app/combustion/issue/DROID-595/write-power-mode-value-to-v1probe-status-and-read-from-firestore

**Note, required by PR https://github.com/combustion-inc/combustion-android-prod/pull/304**

## Description
Rename power mode related classes to match cloud requirements