### PR TITLE
DROID-613 : Fix uninitialized property exception when auto-retry stuck dfu

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/analytics/AnalyticsTracker.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/analytics/AnalyticsTracker.kt
@@ -39,14 +39,32 @@ import kotlinx.coroutines.flow.asSharedFlow
 internal class AnalyticsTracker {
     companion object : SingletonHolder<AnalyticsTracker>({ AnalyticsTracker() })
 
-    private val _analyticsFlow =
-        MutableSharedFlow<AnalyticsEvent>(replay = 5, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val _eventFlow =
+        MutableSharedFlow<AnalyticsEvent>(
+            replay = 0,
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
 
-    val analyticsFlow: SharedFlow<AnalyticsEvent>
-        get() = _analyticsFlow.asSharedFlow()
+    val eventFlow: SharedFlow<AnalyticsEvent>
+        get() = _eventFlow.asSharedFlow()
+
+    private val _exceptionEventFlow =
+        MutableSharedFlow<ExceptionEvent>(
+            replay = 0,
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+
+    val exceptionEventFlow: SharedFlow<ExceptionEvent>
+        get() = _exceptionEventFlow.asSharedFlow()
 
     fun trackEvent(event: AnalyticsEvent) {
-        _analyticsFlow.tryEmit(event)
+        _eventFlow.tryEmit(event)
+    }
+
+    fun trackExceptionEvent(exceptionEvent: ExceptionEvent) {
+        _exceptionEventFlow.tryEmit(exceptionEvent)
     }
 
     fun trackStartDfu(productType: CombustionProductType?, serialNumber: String?) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/analytics/ExceptionEvent.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/analytics/ExceptionEvent.kt
@@ -1,0 +1,34 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: ExceptionEvent.kt
+ * Author:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.analytics
+
+sealed interface ExceptionEvent {
+    data class NonFatalException(val exception: Exception) : ExceptionEvent
+    data class ExceptionContext(val message: String) : ExceptionEvent
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/dfu/DfuService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/dfu/DfuService.kt
@@ -10,5 +10,8 @@ class DfuService : DfuBaseService() {
 
     companion object {
         lateinit var notifyActivity: Class<out Activity>
+
+        fun isNotifyActivitySet(): Boolean =
+            ::notifyActivity.isInitialized
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -39,6 +39,7 @@ import inc.combustion.framework.Combustion
 import inc.combustion.framework.LOG_TAG
 import inc.combustion.framework.analytics.AnalyticsEvent
 import inc.combustion.framework.analytics.AnalyticsTracker
+import inc.combustion.framework.analytics.ExceptionEvent
 import inc.combustion.framework.ble.NetworkManager
 import inc.combustion.framework.ble.device.DeviceID
 import inc.combustion.framework.ble.dfu.DfuManager
@@ -308,7 +309,14 @@ class DeviceManager(
      * Note, flow does not suspend and discards old events.
      */
     val analyticsFlow: SharedFlow<AnalyticsEvent>
-        get() = AnalyticsTracker.instance.analyticsFlow
+        get() = AnalyticsTracker.instance.eventFlow
+
+    /**
+     * Returns a flow of [ExceptionEvent], tracked analytics exception events.
+     * Note, flow does not suspend and discards old events.
+     */
+    val analyticsExceptionsFlow: SharedFlow<ExceptionEvent>
+        get() = AnalyticsTracker.instance.exceptionEventFlow
 
     /**
      * Registers a lambda to be called by the DeviceManager upon binding with the


### PR DESCRIPTION
https://linear.app/combustion/issue/DROID-613/kotlinuninitializedpropertyaccessexception-lateinit-property

**Note, companion app PR is https://github.com/combustion-inc/combustion-android-prod/pull/313**

## Descripion
- Fix uninitialized property exception when auto-retry stuck dfu
- Track nonFatal exceptions
## Tech Notes
- move `DfuService.notifyActivity = notificationTarget` to `DfuManager.start()` for property `notifyActivity` to be set before auto-retry stuck DFU fires.