### PR TITLE
Refactor product types

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/analytics/AnalyticsTracker.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/analytics/AnalyticsTracker.kt
@@ -30,7 +30,7 @@ package inc.combustion.framework.analytics
 
 import inc.combustion.framework.SingletonHolder
 import inc.combustion.framework.analytics.AnalyticsEvent.EventName
-import inc.combustion.framework.service.CombustionProductType
+import inc.combustion.framework.service.dfu.DfuProductType
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -67,18 +67,18 @@ internal class AnalyticsTracker {
         _exceptionEventFlow.tryEmit(exceptionEvent)
     }
 
-    fun trackStartDfu(productType: CombustionProductType?, serialNumber: String?) {
+    fun trackStartDfu(productType: DfuProductType?, serialNumber: String?) {
         val params = genDfuParams(productType, serialNumber)
         trackEvent(AnalyticsEvent(EventName.DFU_STARTED, params))
     }
 
-    fun trackRetryDfu(productType: CombustionProductType?, serialNumber: String?) {
+    fun trackRetryDfu(productType: DfuProductType?, serialNumber: String?) {
         val params = genDfuParams(productType, serialNumber)
         trackEvent(AnalyticsEvent(EventName.DFU_RETRY, params))
     }
 
     private fun genDfuParams(
-        productType: CombustionProductType?,
+        productType: DfuProductType?,
         serialNumber: String?,
     ): Map<String, Any> =
         mutableMapOf<String, Any>().apply {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -616,11 +616,13 @@ internal class NetworkManager(
                     )
                 }
 
-                CombustionProductType.DISPLAY, CombustionProductType.CHARGER -> {
+                CombustionProductType.NODE -> {
                     val device = NodeBleDevice(advertisement.mac, owner, advertisement, adapter)
                     publishNodeFirmwareOnConnectedState(device.getDevice())
                     DeviceHolder.RepeaterHolder(device)
                 }
+
+                CombustionProductType.GAUGE -> TODO()
 
                 else -> NOT_IMPLEMENTED("Unknown type of advertising data")
             }
@@ -815,7 +817,7 @@ internal class NetworkManager(
                     device.firmwareVersion?.let { firmwareVersion ->
                         // Add to firmware state map
                         val node =
-                            FirmwareState.Node(device.id, device.productType, firmwareVersion)
+                            FirmwareState.Node(device.id, device.dfuProductType, firmwareVersion)
                         firmwareStateOfNetwork[device.id] = node
 
                         // publish the list of firmware details for the network

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/DeviceInformationBleDevice.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.LifecycleOwner
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.service.FirmwareVersion
 import inc.combustion.framework.service.ModelInformation
+import inc.combustion.framework.service.dfu.DfuProductType
 
 internal open class DeviceInformationBleDevice(
     mac: String,
@@ -45,34 +46,40 @@ internal open class DeviceInformationBleDevice(
     var hardwareRevision: String? = null
     var modelInformation: ModelInformation? = null
 
+    val dfuProductType: DfuProductType
+        get() = modelInformation?.dfuProductType ?: DfuProductType.fromCombustionProductType(
+            productType
+        )
+
     override fun disconnect() {
         serialNumber = null
         firmwareVersion = null
         hardwareRevision = null
         super.disconnect()
     }
+
     suspend fun readSerialNumber() {
-        if(isConnected.get()) {
+        if (isConnected.get()) {
             serialNumber = readSerialNumberCharacteristic()?.uppercase()
         }
     }
 
     suspend fun readFirmwareVersion() {
-        if(isConnected.get()) {
-            firmwareVersion = readFirmwareVersionCharacteristic()?.let {versionString ->
+        if (isConnected.get()) {
+            firmwareVersion = readFirmwareVersionCharacteristic()?.let { versionString ->
                 FirmwareVersion.fromString(versionString = versionString)
             }
         }
     }
 
     suspend fun readHardwareRevision() {
-        if(isConnected.get()) {
+        if (isConnected.get()) {
             hardwareRevision = readHardwareRevisionCharacteristic()
         }
     }
 
     suspend fun readModelInformation() {
-        if(isConnected.get()) {
+        if (isConnected.get()) {
             modelInformation = readModelNumberCharacteristic()?.let { infoString ->
                 ModelInformation.fromString(infoString)
             }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
@@ -33,7 +33,25 @@ import androidx.lifecycle.lifecycleScope
 import inc.combustion.framework.ble.ProbeStatus
 import inc.combustion.framework.ble.scanning.CombustionAdvertisingData
 import inc.combustion.framework.ble.uart.LogResponse
-import inc.combustion.framework.service.*
+import inc.combustion.framework.service.CombustionProductType
+import inc.combustion.framework.service.DeviceConnectionState
+import inc.combustion.framework.service.FirmwareVersion
+import inc.combustion.framework.service.FoodSafeData
+import inc.combustion.framework.service.FoodSafeStatus
+import inc.combustion.framework.service.ModelInformation
+import inc.combustion.framework.service.OverheatingSensors
+import inc.combustion.framework.service.PredictionStatus
+import inc.combustion.framework.service.ProbeBatteryStatus
+import inc.combustion.framework.service.ProbeColor
+import inc.combustion.framework.service.ProbeID
+import inc.combustion.framework.service.ProbeMode
+import inc.combustion.framework.service.ProbePowerMode
+import inc.combustion.framework.service.ProbePredictionMode
+import inc.combustion.framework.service.ProbeTemperatures
+import inc.combustion.framework.service.ProbeVirtualSensors
+import inc.combustion.framework.service.SessionInformation
+import inc.combustion.framework.service.ThermometerPreferences
+import inc.combustion.framework.service.dfu.DfuProductType
 import kotlinx.coroutines.launch
 import kotlin.concurrent.fixedRateTimer
 import kotlin.random.Random
@@ -201,6 +219,7 @@ internal class SimulatedProbeBleDevice(
         deviceInfoHardwareRevision = "v2.3.4"
         deviceInfoModelInformation = ModelInformation(
             productType = CombustionProductType.PROBE,
+            dfuProductType = DfuProductType.PROBE,
             sku = "ABCDEF",
             manufacturingLot = "98765"
         )

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/dfu/PerformDfuDelegate.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/dfu/PerformDfuDelegate.kt
@@ -122,13 +122,12 @@ class PerformDfuDelegate(
 
 //    private fun genDeviceName(): String {
 //        val unique5Digits = String.format("%05d", Random.nextInt(0, 100000))
-//        val product = when (state.value.device.productType) {
-//            CombustionProductType.PROBE -> "Thermom"
-//            CombustionProductType.DISPLAY -> "Display"
-//            CombustionProductType.CHARGER -> "Charger"
-//            // TODO : support "Gauge"
+//        val product = when (state.value.device.dfuProductType) {
+//            DfuProductType.PROBE -> "Thermom"
+//            DfuProductType.DISPLAY -> "Display"
+//            DfuProductType.CHARGER -> "Charger"
+//            DfuProductType.GAUGE -> "Gauge"
 //            else -> "Thermom"
-//
 //        }
 //        return "${product}_DFU_$unique5Digits"
 //    }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/scanning/BaseAdvertisingData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/scanning/BaseAdvertisingData.kt
@@ -134,7 +134,7 @@ open class BaseAdvertisingData(
                 CombustionProductType.UNKNOWN -> {
                     base
                 }
-                CombustionProductType.PROBE, CombustionProductType.CHARGER, CombustionProductType.DISPLAY -> {
+                CombustionProductType.PROBE, CombustionProductType.NODE -> {
                     CombustionAdvertisingData(
                         mac = address,
                         name = name,
@@ -152,6 +152,7 @@ open class BaseAdvertisingData(
                         hopCount = hopCount
                     )
                 }
+                CombustionProductType.GAUGE -> TODO()
             }
         }
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/scanning/CombustionAdvertisingData.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/scanning/CombustionAdvertisingData.kt
@@ -28,7 +28,14 @@
 
 package inc.combustion.framework.ble.scanning
 
-import inc.combustion.framework.service.*
+import inc.combustion.framework.service.CombustionProductType
+import inc.combustion.framework.service.OverheatingSensors
+import inc.combustion.framework.service.ProbeBatteryStatus
+import inc.combustion.framework.service.ProbeColor
+import inc.combustion.framework.service.ProbeID
+import inc.combustion.framework.service.ProbeMode
+import inc.combustion.framework.service.ProbeTemperatures
+import inc.combustion.framework.service.ProbeVirtualSensors
 
 internal class CombustionAdvertisingData(
     mac: String,
@@ -45,11 +52,11 @@ internal class CombustionAdvertisingData(
     val virtualSensors: ProbeVirtualSensors,
     val overheatingSensors: OverheatingSensors,
     val hopCount: UInt = 0u,
-): BaseAdvertisingData(mac, name, rssi, productType, isConnectable) {
+) : BaseAdvertisingData(mac, name, rssi, productType, isConnectable) {
 
     val isRepeater: Boolean
         get() {
-            return productType == CombustionProductType.CHARGER || productType == CombustionProductType.DISPLAY
+            return productType.isRepeater
         }
 
     override fun toString(): String {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeHeartbeatRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeHeartbeatRequest.kt
@@ -81,9 +81,9 @@ internal class NodeHeartbeatRequest (
                 val sn = when (pt) {
                     CombustionProductType.PROBE ->
                         Integer.toHexString(data.getLittleEndianUInt32At(SERIAL_NUMBER_INDEX).toInt()).uppercase()
-                    CombustionProductType.DISPLAY,
-                    CombustionProductType.CHARGER ->
+                    CombustionProductType.NODE ->
                         data.trimmedStringFromRange(SERIAL_NUMBER_INDEX until SERIAL_NUMBER_INDEX + NODE_SERIAL_NUMBER_SIZE)
+                    CombustionProductType.GAUGE -> TODO()
                     CombustionProductType.UNKNOWN -> {
                         Log.w(LOG_TAG, "Unknown product type ($pt) encountered")
                         ""

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Device.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Device.kt
@@ -30,6 +30,7 @@ package inc.combustion.framework.service
 
 import inc.combustion.framework.Constants.Companion.MIN_RSSI
 import inc.combustion.framework.ble.device.DeviceID
+import inc.combustion.framework.service.dfu.DfuProductType
 
 /**
  * Representation of a Combustion device.
@@ -54,4 +55,9 @@ data class Device(
     val connectionState: DeviceConnectionState = DeviceConnectionState.DISCONNECTED,
 ) {
     val id: DeviceID = mac
+
+    val dfuProductType: DfuProductType
+        get() = modelInformation?.dfuProductType
+            ?: productType?.let { DfuProductType.fromCombustionProductType(it) }
+            ?: DfuProductType.UNKNOWN
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ModelInformation.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ModelInformation.kt
@@ -28,8 +28,11 @@
 
 package inc.combustion.framework.service
 
+import inc.combustion.framework.service.dfu.DfuProductType
+
 data class ModelInformation(
     val productType: CombustionProductType,
+    val dfuProductType: DfuProductType,
     val sku: String,
     val manufacturingLot: String
 ) {
@@ -52,6 +55,7 @@ data class ModelInformation(
 
                     return ModelInformation(
                         productType = CombustionProductType.PROBE,
+                        dfuProductType = DfuProductType.PROBE,
                         sku = split[0],
                         manufacturingLot = split[1]
                     )
@@ -62,8 +66,10 @@ data class ModelInformation(
                         val skuLot = split[1].split("-")
 
                         if (skuLot.size == 2) {
+                            val split0 = split[0]
                             return ModelInformation(
-                                productType = CombustionProductType.fromModelString(split[0]),
+                                productType = CombustionProductType.fromModelString(split0),
+                                dfuProductType = DfuProductType.fromModelString(split0),
                                 sku = skuLot[0],
                                 manufacturingLot = skuLot[1]
                             )
@@ -74,6 +80,7 @@ data class ModelInformation(
 
             return ModelInformation(
                 productType = CombustionProductType.UNKNOWN,
+                dfuProductType = DfuProductType.UNKNOWN,
                 sku = "",
                 manufacturingLot = ""
             )

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/NodeFirmwareState.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/NodeFirmwareState.kt
@@ -29,13 +29,14 @@
 package inc.combustion.framework.service
 
 import inc.combustion.framework.ble.device.DeviceID
+import inc.combustion.framework.service.dfu.DfuProductType
 
 data class FirmwareState(
     val nodes: List<Node>
 ) {
     data class Node(
         val id: DeviceID,
-        val type: CombustionProductType,
+        val type: DfuProductType,
         val firmwareVersion: FirmwareVersion,
     )
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/dfu/DfuProductType.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/dfu/DfuProductType.kt
@@ -1,11 +1,11 @@
 /*
  * Project: Combustion Inc. Android Framework
- * File: CombustionProductType.kt
+ * File: DfuProductType.kt
  * Author:
  *
  * MIT License
  *
- * Copyright (c) 2023. Combustion Inc.
+ * Copyright (c) 2025. Combustion Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,38 +26,43 @@
  * SOFTWARE.
  */
 
-package inc.combustion.framework.service
+package inc.combustion.framework.service.dfu
 
-enum class CombustionProductType(val type: UByte) {
-    UNKNOWN(0x00u),
-    PROBE(0x01u),
-    NODE(0x02u),
-    GAUGE(0x03u);
+import inc.combustion.framework.service.CombustionProductType
+
+enum class DfuProductType {
+    UNKNOWN,
+    PROBE,
+    DISPLAY,
+    CHARGER,
+    GAUGE;
 
     companion object {
-        fun fromUByte(byte: UByte): CombustionProductType {
-            return when (byte) {
-                PROBE.type -> PROBE
-                NODE.type -> NODE
-                GAUGE.type -> GAUGE
-                else -> UNKNOWN
-            }
-        }
 
         /**
-         * Returns the [CombustionProductType] according to the string in the DIS Model Number
+         * Returns the [DfuProductType] according to the string in the DIS Model Number
          * characteristic.
          */
-        fun fromModelString(model: String): CombustionProductType {
+        fun fromModelString(model: String): DfuProductType {
             return when (model) {
-                "Timer" -> NODE
-                "Charger" -> NODE
+                "Timer" -> DISPLAY
+                "Charger" -> CHARGER
                 "" -> PROBE
                 "Gauge" -> GAUGE
                 else -> UNKNOWN
             }
         }
-    }
 
-    val isRepeater: Boolean get() = (this != PROBE) && (this != UNKNOWN)
+        /**
+         * Returns the [DfuProductType] from [CombustionProductType].
+         * NB, not ideal since [CombustionProductType.NODE] can be either [CHARGER] or [DISPLAY]
+         */
+        fun fromCombustionProductType(productType: CombustionProductType): DfuProductType =
+            when (productType) {
+                CombustionProductType.NODE -> CHARGER // NB, could also be DISPLAY - not ideal!
+                CombustionProductType.PROBE -> PROBE
+                CombustionProductType.GAUGE -> GAUGE
+                else -> UNKNOWN
+            }
+    }
 }

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/service/ModelInformationTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/service/ModelInformationTest.kt
@@ -28,6 +28,7 @@
 
 package inc.combustion.framework.service
 
+import inc.combustion.framework.service.dfu.DfuProductType
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -37,6 +38,7 @@ internal class ModelInformationTest {
         val mi = ModelInformation.fromString("10010101:20220914")
 
         assertEquals(CombustionProductType.PROBE, mi.productType)
+        assertEquals(DfuProductType.PROBE, mi.dfuProductType)
         assertEquals("10010101", mi.sku)
         assertEquals("20220914", mi.manufacturingLot)
     }
@@ -45,7 +47,8 @@ internal class ModelInformationTest {
     fun `Check Timer Model Information String`() {
         val mi = ModelInformation.fromString("Timer 123-ABC")
 
-        assertEquals(CombustionProductType.DISPLAY, mi.productType)
+        assertEquals(CombustionProductType.NODE, mi.productType)
+        assertEquals(DfuProductType.DISPLAY, mi.dfuProductType)
         assertEquals("123", mi.sku)
         assertEquals("ABC", mi.manufacturingLot)
     }
@@ -54,16 +57,45 @@ internal class ModelInformationTest {
     fun `Check Charger Model Information String`() {
         val mi = ModelInformation.fromString("Charger 123-ABC")
 
-        assertEquals(CombustionProductType.CHARGER, mi.productType)
+        assertEquals(CombustionProductType.NODE, mi.productType)
+        assertEquals(DfuProductType.CHARGER, mi.dfuProductType)
         assertEquals("123", mi.sku)
         assertEquals("ABC", mi.manufacturingLot)
     }
 
     @Test
     fun `Check Malformed Strings Fail`() {
-        assertEquals(CombustionProductType.UNKNOWN, ModelInformation.fromString("1001010120220914").productType)
-        assertEquals(CombustionProductType.UNKNOWN, ModelInformation.fromString("10010101 20220914").productType)
-        assertEquals(CombustionProductType.UNKNOWN, ModelInformation.fromString("Timer 20220914").productType)
-        assertEquals(CombustionProductType.UNKNOWN, ModelInformation.fromString("Charger123-ABC").productType)
+        assertEquals(
+            CombustionProductType.UNKNOWN,
+            ModelInformation.fromString("1001010120220914").productType
+        )
+        assertEquals(
+            DfuProductType.UNKNOWN,
+            ModelInformation.fromString("1001010120220914").dfuProductType
+        )
+        assertEquals(
+            CombustionProductType.UNKNOWN,
+            ModelInformation.fromString("10010101 20220914").productType
+        )
+        assertEquals(
+            DfuProductType.UNKNOWN,
+            ModelInformation.fromString("10010101 20220914").dfuProductType
+        )
+        assertEquals(
+            CombustionProductType.UNKNOWN,
+            ModelInformation.fromString("Timer 20220914").productType
+        )
+        assertEquals(
+            DfuProductType.UNKNOWN,
+            ModelInformation.fromString("Timer 20220914").dfuProductType
+        )
+        assertEquals(
+            CombustionProductType.UNKNOWN,
+            ModelInformation.fromString("Charger123-ABC").productType
+        )
+        assertEquals(
+            DfuProductType.UNKNOWN,
+            ModelInformation.fromString("Charger123-ABC").dfuProductType
+        )
     }
 }


### PR DESCRIPTION
Note:
- related to https://linear.app/combustion/issue/DROID-579/add-ble-interface-updates-for-gauge
- merge to feature branch
- GAUGE is now known but not yet handled -- detecting one may crash app because of `TODO()`
- app changes referencing these changes in PR https://github.com/combustion-inc/combustion-android-prod/pull/317

## Description
Since parsing GAUGE requirements contradicts current parsing implementation of `CombustionProductType`:
- rename `CombustionProductType.DISPLAY` to `CombustionProductType.NODE` since covers both display and booster
- replace `CombustionProductType.CHARGER` at `0x03u` with `CombustionProductType.GAUGE`
- move unique product identifiers to new `DfuProductType` used for DFU related logic and where differentiate between display and booster
