### PR TITLE
DROID-581 : more linking support for Gauge

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeManager.kt
@@ -32,33 +32,13 @@ import android.util.Log
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import inc.combustion.framework.LOG_TAG
-import inc.combustion.framework.ble.device.DeviceID
-import inc.combustion.framework.ble.device.DeviceInformationBleDevice
-import inc.combustion.framework.ble.device.GaugeBleDevice
-import inc.combustion.framework.ble.device.SimulatedGaugeBleDevice
-import inc.combustion.framework.ble.device.UartCapableGauge
+import inc.combustion.framework.ble.device.*
 import inc.combustion.framework.ble.scanning.GaugeAdvertisingData
 import inc.combustion.framework.ble.uart.meatnet.NodeReadGaugeLogsResponse
-import inc.combustion.framework.service.DeviceConnectionState
-import inc.combustion.framework.service.DeviceManager
-import inc.combustion.framework.service.FirmwareVersion
-import inc.combustion.framework.service.Gauge
-import inc.combustion.framework.service.HighLowAlarmStatus
-import inc.combustion.framework.service.ModelInformation
-import inc.combustion.framework.service.ProbeUploadState
-import inc.combustion.framework.service.SessionInformation
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.Dispatchers
+import inc.combustion.framework.service.*
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.*
 
 internal class GaugeManager(
     mac: String,
@@ -508,6 +488,8 @@ internal class GaugeManager(
                 highLowAlarmStatus = status.highLowAlarmStatus,
                 gaugeStatusFlags = status.gaugeStatusFlags,
                 temperatureCelsius = if (status.gaugeStatusFlags.sensorPresent) status.temperature else null,
+                newRecordFlag = status.isNewRecord,
+                hopCount = status.hopCount.hopCount,
             )
 
             // redundantly check for device information

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeStatus.kt
@@ -41,6 +41,7 @@ data class GaugeStatus(
     val batteryPercentage: Int,
     val highLowAlarmStatus: HighLowAlarmStatus,
     val isNewRecord: Boolean,
+    val hopCount: HopCount,
 ) : SpecializedDeviceStatus {
 
     override val mode: ProbeMode = ProbeMode.NORMAL
@@ -55,6 +56,7 @@ data class GaugeStatus(
         private val BATTERY_PERCENTAGE_RANGE = 17..17
         private val HIGH_LOW_ALARM_RANGE = 18..21
         private val NEW_RECORD_FLAG_RANGE = 22..22
+        private val HOP_COUNT_RANGE = 23..23
 
         val RAW_SIZE = NEW_RECORD_FLAG_RANGE.last + 1
 
@@ -82,6 +84,8 @@ data class GaugeStatus(
             val isNewRecord: Boolean =
                 data.getLittleEndianUShortAt(NEW_RECORD_FLAG_RANGE.first).toInt() == 1
 
+            val hopCount: HopCount = HopCount.fromUByte(data.sliceArray(HOP_COUNT_RANGE)[0])
+
             return GaugeStatus(
                 sessionInformation = sessionInformation,
                 samplePeriod = samplePeriod,
@@ -92,6 +96,7 @@ data class GaugeStatus(
                 batteryPercentage = batteryPercentage,
                 highLowAlarmStatus = highLowAlarmStatus,
                 isNewRecord = isNewRecord,
+                hopCount = hopCount,
             )
         }
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -12,7 +12,7 @@ import inc.combustion.framework.ble.uart.meatnet.GenericNodeRequest
 import inc.combustion.framework.ble.uart.meatnet.GenericNodeResponse
 import inc.combustion.framework.ble.uart.meatnet.NodeReadFeatureFlagsRequest
 import inc.combustion.framework.ble.uart.meatnet.NodeReadFeatureFlagsResponse
-import inc.combustion.framework.ble.uart.meatnet.NodeReadProbeLogsRequest
+import inc.combustion.framework.ble.uart.meatnet.NodeReadGaugeLogsRequest
 import inc.combustion.framework.ble.uart.meatnet.NodeRequest
 import inc.combustion.framework.ble.uart.meatnet.NodeResponse
 import inc.combustion.framework.ble.uart.meatnet.NodeSetHighLowAlarmRequest
@@ -140,7 +140,7 @@ internal class NodeBleDevice(
         minSequence: UInt,
         maxSequence: UInt,
     ) {
-        sendUartRequest(NodeReadProbeLogsRequest(serialNumber, minSequence, maxSequence))
+        sendUartRequest(NodeReadGaugeLogsRequest(serialNumber, minSequence, maxSequence))
     }
 
     override fun connect() {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeRequest.kt
@@ -83,7 +83,7 @@ internal open class NodeRequest(
             var crcData = data.drop(4).toUByteArray()
             // Prevent index out of bounds or negative value
             if (crcData.size < crcDataLength) {
-                Log.w(LOG_TAG, "Invalid crc data length")
+                Log.w(LOG_TAG, "Invalid crc data length for request of messageType $messageType")
                 return null
             }
             crcData = crcData.dropLast(crcData.size - crcDataLength).toUByteArray()
@@ -91,7 +91,7 @@ internal open class NodeRequest(
             val calculatedCRC = crcData.getCRC16CCITT()
 
             if(crc != calculatedCRC) {
-                Log.w(LOG_TAG, "Invalid CRC")
+                Log.w(LOG_TAG, "Invalid CRC for request of messageType $messageType")
                 return null
             }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -108,7 +108,7 @@ internal open class NodeResponse(
             var crcData = data.drop(4).toUByteArray()
             // prevent index out of bounds or negative value
             if (crcData.size < crcDataLength) {
-                Log.w(LOG_TAG, "Invalid crc data length")
+                Log.w(LOG_TAG, "Invalid crc data length for response of messageType $messageType")
                 return null
             }
             crcData = crcData.dropLast(crcData.size - crcDataLength).toUByteArray()

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionService.kt
@@ -168,13 +168,14 @@ class CombustionService : LifecycleService() {
                 NetworkManager.instance.bluetoothAdapterStateReceiver,
                 NetworkManager.instance.bluetoothAdapterStateIntentFilter,
             )
-            onServiceStartedCallback?.invoke()
-            onServiceStartedCallback = null
         }
 
         startForeground()
 
         serviceIsStarted.set(true)
+
+        onServiceStartedCallback?.invoke()
+        onServiceStartedCallback = null
 
         Log.d(LOG_TAG, "Combustion Android Service Started...")
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Gauge.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Gauge.kt
@@ -46,6 +46,8 @@ data class Gauge(
     val temperatureCelsius: SensorTemperature? = null,
     val recordsDownloaded: Int = 0,
     val logUploadPercent: UInt = 0u,
+    val newRecordFlag: Boolean = false,
+    override val hopCount: UInt? = null,
 ) : SpecializedDevice {
 
     companion object {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/HighLowAlarmStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/HighLowAlarmStatus.kt
@@ -90,4 +90,7 @@ data class HighLowAlarmStatus(
 
     val isTripped: Boolean
         get() = highStatus.tripped || lowStatus.tripped
+
+    val isAlarming: Boolean
+        get() = highStatus.alarming || lowStatus.alarming
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/LoggedDataPoint.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/LoggedDataPoint.kt
@@ -43,6 +43,8 @@ interface LoggedDataPoint : Comparable<LoggedDataPoint> {
         }
     }
 
+    fun copyWith(sessionId: UInt = this.sessionId, sequenceNumber: UInt = this.sequenceNumber, timestamp: Date = this.timestamp) : LoggedDataPoint
+
     companion object {
         fun getTimestamp(
             sessionStart: Date?,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/LoggedGaugeDataPoint.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/LoggedGaugeDataPoint.kt
@@ -33,7 +33,7 @@ import inc.combustion.framework.ble.uart.meatnet.NodeReadGaugeLogsResponse
 import inc.combustion.framework.service.LoggedDataPoint.Companion.getTimestamp
 import java.util.Date
 
-class LoggedGaugeDataPoint(
+data class LoggedGaugeDataPoint(
     override val sessionId: UInt,
     override val sequenceNumber: UInt,
     override val timestamp: Date,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/LoggedGaugeDataPoint.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/LoggedGaugeDataPoint.kt
@@ -41,6 +41,16 @@ data class LoggedGaugeDataPoint(
     val sensorPresent: Boolean,
 ) : LoggedDataPoint {
 
+    override fun copyWith(
+        sessionId: UInt,
+        sequenceNumber: UInt,
+        timestamp: Date
+    ): LoggedDataPoint = this.copy(
+        sessionId = sessionId,
+        sequenceNumber = sequenceNumber,
+        timestamp = timestamp
+    )
+
     internal companion object {
         fun fromDeviceStatus(
             status: GaugeStatus,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/LoggedProbeDataPoint.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/LoggedProbeDataPoint.kt
@@ -71,6 +71,16 @@ data class LoggedProbeDataPoint(
             return virtualAmbientSensor.temperatureFrom(temperatures)
         }
 
+    override fun copyWith(
+        sessionId: UInt,
+        sequenceNumber: UInt,
+        timestamp: Date
+    ): LoggedDataPoint = this.copy(
+        sessionId = sessionId,
+        sequenceNumber = sequenceNumber,
+        timestamp = timestamp
+    )
+
     internal companion object {
         fun fromDeviceStatus(
             sessionId: UInt,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
@@ -112,7 +112,7 @@ data class Probe(
     val predictionSeconds: UInt? = null,
     val rawPredictionSeconds: UInt? = null,
     val estimatedCoreCelsius: Double? = null,
-    val hopCount: UInt? = null,
+    override val hopCount: UInt? = null,
     override val statusNotificationsStale: Boolean = false,
     val predictionStale: Boolean = false,
     val overheatingSensors: List<Int> = listOf(),

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
@@ -40,6 +40,7 @@ interface SpecializedDevice {
     val uploadState: ProbeUploadState
     val minSequence: UInt?
     val maxSequence: UInt?
+    val hopCount: UInt?
 
     val isOverheating: Boolean
 


### PR DESCRIPTION
## Note
- merge to feature branch
- matching app PR https://github.com/combustion-inc/combustion-android-prod/pull/322

## Description
- Support linking/unlinking gauge
- make framework more robust to being accessed while still initializing
- add support for missing gauge status properties for cloud
- fix requesting gauge logs not firing

## Tech Notes
- `doWhenNetworkManagerInitialized()` delays executing until `NetworkManager` has been initialized
- add gauge to `unlinkDevice()` logic