### PR TITLE
Fix app v2.5.1 thinks Gauge is an overheating probe

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionProductType.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionProductType.kt
@@ -31,8 +31,8 @@ package inc.combustion.framework.service
 enum class CombustionProductType(val type: UByte) {
     UNKNOWN(0x00u),
     PROBE(0x01u),
-    DISPLAY(0x02u),
-    CHARGER(0x03u);
+    DISPLAY(0x02u), // TODO : rename to NODE
+    CHARGER(0x03u); // TODO : rename to GAUGE
 
     companion object {
         fun fromUByte(byte: UByte) : CombustionProductType {


### PR DESCRIPTION
## Desciption 
- Fix app v2.5.1 (pre gauge support) thinks Gauge is an overheating probe

## Tech Notes
- When handling advertisements ignore those from product types that are not supported, i.e. only consider PROBE and DISPLAY (renamed to NODE in gauge branch)