### PR TITLE
DROID-644: Add full meatnet support to gauges

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/BleManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/BleManager.kt
@@ -50,6 +50,11 @@ internal abstract class BleManager {
         const val IGNORE_GAUGES = false
 
         const val OUT_OF_RANGE_TIMEOUT = 15000L
+
+        protected const val STATUS_NOTIFICATIONS_IDLE_POLL_RATE_MS = 1000L
+        protected const val STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS =
+            SpecializedDevice.STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS
+        protected const val STATUS_NOTIFICATIONS_POLL_DELAY_MS = 30000L
     }
 
     abstract val serialNumber: String

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeDataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeDataLinkArbitrator.kt
@@ -32,6 +32,7 @@ import android.util.Log
 import inc.combustion.framework.LOG_TAG
 import inc.combustion.framework.ble.device.DeviceInformationBleDevice
 import inc.combustion.framework.ble.device.GaugeBleDevice
+import inc.combustion.framework.ble.device.NodeBleDevice
 import inc.combustion.framework.ble.device.ProbeBleDevice
 import inc.combustion.framework.ble.device.RepeatedProbeBleDevice
 import inc.combustion.framework.ble.device.SimulatedProbeBleDevice
@@ -59,6 +60,16 @@ internal class GaugeDataLinkArbitrator :
     private var currentStatus: SpecializedDeviceStatus? = null
     private var currentSessionInfo: SessionInformation? = null
 
+    private var repeaterNodesGetter: (() -> List<NodeBleDevice>)? = null
+
+    private val repeaterNodes: List<NodeBleDevice>
+        get() = repeaterNodesGetter?.invoke() ?: emptyList()
+
+    val connectedNodeLinks: List<NodeBleDevice>
+        get() {
+            return repeaterNodes.filter { it.isConnected }
+        }
+
     /**
      * Cleans up all resources associated with this arbitrator.
      *
@@ -78,6 +89,7 @@ internal class GaugeDataLinkArbitrator :
             directConnectionAction(it)
         }
 
+        repeaterNodesGetter = null
         bleDevice = null
     }
 
@@ -95,6 +107,10 @@ internal class GaugeDataLinkArbitrator :
         }
 
         return false
+    }
+
+    fun addRepeaterNodes(repeaterNodesGetter: (() -> List<NodeBleDevice>)) {
+        this.repeaterNodesGetter = repeaterNodesGetter
     }
 
     override fun getPreferredConnectionState(state: DeviceConnectionState): GaugeBleDevice? {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeManager.kt
@@ -35,6 +35,7 @@ import inc.combustion.framework.LOG_TAG
 import inc.combustion.framework.ble.device.DeviceID
 import inc.combustion.framework.ble.device.DeviceInformationBleDevice
 import inc.combustion.framework.ble.device.GaugeBleDevice
+import inc.combustion.framework.ble.device.NodeBleDevice
 import inc.combustion.framework.ble.device.SimulatedGaugeBleDevice
 import inc.combustion.framework.ble.device.UartCapableGauge
 import inc.combustion.framework.ble.scanning.GaugeAdvertisingData
@@ -280,12 +281,16 @@ internal class GaugeManager(
         }
     }
 
+    fun addRepeaters(repeaters: () -> List<NodeBleDevice>) {
+        arbitrator.addRepeaterNodes(repeaters)
+    }
+
     fun addSimulatedGauge(simGauge: SimulatedGaugeBleDevice) {
         if (simulatedGauge != null) return
         var updatedGauge = _deviceFlow.value
 
         // process simulated device status notifications
-        simGauge.observeGaugeStatusUpdates() { status ->
+        simGauge.observeGaugeStatusUpdates { status ->
             handleStatus(status, simulated = true)
             updatedGauge = _deviceFlow.value
         }
@@ -509,7 +514,11 @@ internal class GaugeManager(
         status: GaugeStatus,
         simulated: Boolean = simulatedGauge != null,
     ) {
-        if (simulated || arbitrator.shouldUpdateDataFromStatusForNormalMode(status, sessionInfo)) {
+        if (simulated || arbitrator.shouldUpdateDataFromStatusForNormalMode(
+                status,
+                sessionInfo,
+            )
+        ) {
             statusNotificationsMonitor.activity()
 
             handleSessionInfo(
@@ -578,7 +587,7 @@ internal class GaugeManager(
 
     fun setHighLowAlarmStatus(
         highLowAlarmStatus: HighLowAlarmStatus,
-        completionHandler: (Boolean) -> Unit
+        completionHandler: (Boolean) -> Unit,
     ) {
         val onCompletion: (Boolean) -> Unit = { success ->
             if (success) {
@@ -594,24 +603,67 @@ internal class GaugeManager(
         val requestId = makeRequestId()
         simulatedGauge?.sendSetHighLowAlarmStatus(highLowAlarmStatus, requestId) { status, _ ->
             onCompletion(status)
+        } ?: arbitrator.directLink?.sendSetHighLowAlarmStatus(
+            highLowAlarmStatus,
+            requestId,
+        ) { status, _ ->
+            onCompletion(status)
         } ?: run {
-            // if there is a direct link to the probe, then use that
-            arbitrator.directLink?.sendSetHighLowAlarmStatus(
-                highLowAlarmStatus,
-                requestId,
-            ) { status, _ ->
-                onCompletion(status)
-            } ?: run {
+            val nodeLinks = arbitrator.connectedNodeLinks
+            if (nodeLinks.isNotEmpty()) {
+                var handled = false
+                nodeLinks.forEach { node ->
+                    node.sendSetHighLowAlarmStatus(
+                        serialNumber,
+                        highLowAlarmStatus,
+                        requestId,
+                    ) { status, _ ->
+                        if (!handled) {
+                            handled = true
+                            onCompletion(status)
+                        }
+                    }
+                }
+
+            } else {
                 onCompletion(false)
             }
         }
     }
 
     override fun sendLogRequest(startSequenceNumber: UInt, endSequenceNumber: UInt) {
-        simulatedGauge?.sendGaugeLogRequest(startSequenceNumber, endSequenceNumber) {
+        val requestId = makeRequestId()
+        val callback: suspend (NodeReadGaugeLogsResponse) -> Unit = {
             _logResponseFlow.emit(it)
-        } ?: arbitrator.directLink?.sendGaugeLogRequest(startSequenceNumber, endSequenceNumber) {
-            _logResponseFlow.emit(it)
+        }
+        simulatedGauge?.sendGaugeLogRequest(
+            startSequenceNumber,
+            endSequenceNumber,
+            requestId,
+            callback,
+        ) ?: arbitrator.directLink?.sendGaugeLogRequest(
+            startSequenceNumber,
+            endSequenceNumber,
+            requestId,
+            callback,
+        ) ?: run {
+            val nodeLinks = arbitrator.connectedNodeLinks
+            if (nodeLinks.isNotEmpty()) {
+                var handledSequenceNumbers = mutableSetOf<UInt>()
+                nodeLinks.forEach { node ->
+                    node.sendGaugeLogRequest(
+                        serialNumber,
+                        startSequenceNumber,
+                        endSequenceNumber,
+                        requestId,
+                    ) {
+                        if (!handledSequenceNumbers.contains(it.sequenceNumber)) {
+                            handledSequenceNumbers.add(it.sequenceNumber)
+                            callback(it)
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeManager.kt
@@ -61,6 +61,20 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
+/**
+ * This class is responsible for managing and arbitrating the data links to a gauge.
+ * When MeatNet is enabled that includes data links through repeater devices over
+ * MeatNet and direct links to gauge.  When MeatNet is disabled, this class
+ * manages only direct links to the gauge. The class is responsible for presenting
+ * a common interface over both scenarios.
+ *
+ * @property owner LifecycleOwner for coroutine scope.
+ * @property settings Service settings.
+ * @constructor
+ * Constructs a gauge manager
+ *
+ * @param serialNumber The serial number of the gauge being managed.
+ */
 internal class GaugeManager(
     mac: String,
     serialNumber: String,
@@ -68,12 +82,6 @@ internal class GaugeManager(
     private val settings: DeviceManager.Settings,
     private val dfuDisconnectedNodeCallback: (DeviceID) -> Unit,
 ) : BleManager() {
-    companion object {
-        private const val GAUGE_STATUS_NOTIFICATIONS_IDLE_POLL_RATE_MS = 1000L
-        private const val GAUGE_STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS =
-            Gauge.GAUGE_STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS
-        private const val GAUGE_STATUS_NOTIFICATIONS_POLL_DELAY_MS = 30000L
-    }
 
     // encapsulates logic for managing network data links
     override val arbitrator = GaugeDataLinkArbitrator()
@@ -196,13 +204,13 @@ internal class GaugeManager(
             ) {
                 // Wait before starting to monitor prediction status, this allows for initial
                 // connection time
-                delay(GAUGE_STATUS_NOTIFICATIONS_POLL_DELAY_MS)
+                delay(STATUS_NOTIFICATIONS_POLL_DELAY_MS)
 
                 while (isActive) {
-                    delay(GAUGE_STATUS_NOTIFICATIONS_IDLE_POLL_RATE_MS)
+                    delay(STATUS_NOTIFICATIONS_IDLE_POLL_RATE_MS)
 
                     val statusNotificationsStale =
-                        statusNotificationsMonitor.isIdle(GAUGE_STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS)
+                        statusNotificationsMonitor.isIdle(STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS)
                     val shouldUpdate =
                         statusNotificationsStale != _deviceFlow.value.statusNotificationsStale
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeStatus.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeStatus.kt
@@ -28,7 +28,12 @@
 
 package inc.combustion.framework.ble
 
-import inc.combustion.framework.service.*
+import inc.combustion.framework.service.GaugeStatusFlags
+import inc.combustion.framework.service.HighLowAlarmStatus
+import inc.combustion.framework.service.HopCount
+import inc.combustion.framework.service.ProbeMode
+import inc.combustion.framework.service.SensorTemperature
+import inc.combustion.framework.service.SessionInformation
 import inc.combustion.framework.toPercentage
 
 data class GaugeStatus(
@@ -68,9 +73,14 @@ data class GaugeStatus(
             val sessionInformation =
                 SessionInformation(sessionID = sessionID, samplePeriod = samplePeriod)
 
-            val temperature = SensorTemperature.fromRawDataStart(data.sliceArray(RAW_TEMP_RANGE))
             val gaugeStatusFlags =
                 GaugeStatusFlags.fromRawByte(data.sliceArray(STATUS_FLAGS_RANGE)[0])
+
+            val temperature = if (gaugeStatusFlags.sensorPresent) {
+                SensorTemperature.fromRawDataStart(data.sliceArray(RAW_TEMP_RANGE))
+            } else {
+                SensorTemperature.NO_DATA
+            }
 
             val minSequenceNumber = data.getLittleEndianUInt32At(MIN_SEQ_RANGE.first)
             val maxSequenceNumber = data.getLittleEndianUInt32At(MAX_SEQ_RANGE.first)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -173,12 +173,12 @@ internal class NetworkManager(
                     .collect { deviceIds ->
                         deviceIds.forEach { deviceId ->
                             when (val node = devices[deviceId]) {
-                                is DeviceHolder.ProbeHolder -> NOT_IMPLEMENTED("Unsupported device type")
+                                is DeviceHolder.ProbeHolder -> NOT_IMPLEMENTED("subscribeToNodeFlow is not implemented for probe with id = $deviceId, type = ${node.probe.productType}, and serialNumber = ${node.probe.serialNumber}")
                                 is DeviceHolder.RepeaterHolder -> {
                                     updateConnectedNodes(node.repeater)
                                 }
 
-                                else -> NOT_IMPLEMENTED("Unknown device type")
+                                else -> NOT_IMPLEMENTED("subscribeToNodeFlow is not implemented for unknown device $node with id = $deviceId")
                             }
                         }
                     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -922,11 +922,22 @@ internal class NetworkManager(
 
         if (gaugeManagers[serialNumber]?.hasGauge() == false) {
             (devices[deviceId] as? DeviceHolder.RepeaterHolder)?.gauge?.let { gaugeBleDevice ->
-                gaugeManagers[serialNumber]?.addGauge(
-                    gauge = gaugeBleDevice,
-                    baseDevice = gaugeBleDevice.baseDevice,
-                    advertisement = advertisement,
-                )
+                gaugeManagers[serialNumber]?.let { manager ->
+                    manager.addGauge(
+                        gauge = gaugeBleDevice,
+                        baseDevice = gaugeBleDevice.baseDevice,
+                        advertisement = advertisement,
+                    )
+                    manager.addRepeaters {
+                        devices.values.toList().filterIsInstance<DeviceHolder.RepeaterHolder>()
+                            .filter {
+                                it.gauge?.serialNumber != gaugeBleDevice.serialNumber
+                            }
+                            .map {
+                                it.repeater
+                            }
+                    }
+                }
             }
         }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -81,7 +81,7 @@ import kotlinx.coroutines.launch
  * manages only direct links to temperature probes.  The class is responsible for presenting
  * a common interface over both scenarios.
  *
- * @property owner LifecycleOnwer for coroutine scope.
+ * @property owner LifecycleOwner for coroutine scope.
  * @property settings Service settings.
  * @constructor
  * Constructs a probe manager
@@ -95,12 +95,8 @@ internal class ProbeManager(
     private val dfuDisconnectedNodeCallback: (DeviceID) -> Unit
 ) : BleManager() {
     companion object {
-        private const val PROBE_STATUS_NOTIFICATIONS_IDLE_POLL_RATE_MS = 1000L
-        private const val PROBE_STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS =
-            Probe.PROBE_STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS
         private const val MEATNET_STATUS_NOTIFICATIONS_TIMEOUT_MS = 30_000L
         private const val PREDICTION_IDLE_TIMEOUT_MS = Probe.PREDICTION_IDLE_TIMEOUT_MS
-        private const val PROBE_STATUS_NOTIFICATIONS_POLL_DELAY_MS = 30000L
         private const val PROBE_INSTANT_READ_IDLE_TIMEOUT_MS = 5000L
     }
 
@@ -618,34 +614,6 @@ internal class ProbeManager(
         }
     }
 
-//    fun finish(deviceIdsToDisconnect: Set<DeviceID>? = null) {
-//        Log.d(LOG_TAG, "ProbeManager.finish($deviceIdsToDisconnect) for ($serialNumber)")
-//
-//        arbitrator.finish(
-//            nodeAction = {
-//                // There's a couple specific things that come out of unlinking a probe that need to
-//                // be addressed here:
-//                //
-//                // - Jobs are created on repeated probes (nodes) that need to be cancelled so that
-//                //   we don't continue to obtain data for probes that we're disconnected from. If
-//                //   all jobs on a node are blindly cancelled, then we'll likely cancel jobs that
-//                //   are still needed for other probes connected to this node. The [jobKey]
-//                //   parameter allows for selective cancellation of jobs.
-//                // - On a related note, we need to be able to selectively disconnect from nodes as
-//                //   some are still providing data from other probes.
-//                it.finish(
-//                    jobKey = serialNumber,
-//                    disconnect = deviceIdsToDisconnect?.contains(it.id) ?: true
-//                )
-//            },
-//            directConnectionAction = {
-//                it.disconnect()
-//            }
-//        )
-//
-//        jobManager.cancelJobs()
-//    }
-
     private fun observe(base: ProbeBleDeviceBase) {
         if (base is ProbeBleDevice) {
             _deviceFlow.update {
@@ -692,13 +660,13 @@ internal class ProbeManager(
             ) {
                 // Wait before starting to monitor prediction status, this allows for initial
                 // connection time
-                delay(PROBE_STATUS_NOTIFICATIONS_POLL_DELAY_MS)
+                delay(STATUS_NOTIFICATIONS_POLL_DELAY_MS)
 
                 while (isActive) {
-                    delay(PROBE_STATUS_NOTIFICATIONS_IDLE_POLL_RATE_MS)
+                    delay(STATUS_NOTIFICATIONS_IDLE_POLL_RATE_MS)
 
                     val statusNotificationsStale =
-                        statusNotificationsMonitor.isIdle(PROBE_STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS)
+                        statusNotificationsMonitor.isIdle(STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS)
                     val predictionStale =
                         predictionMonitor.isIdle(PREDICTION_IDLE_TIMEOUT_MS) && _deviceFlow.value.isPredicting
                     val shouldUpdate =

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/GaugeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/GaugeBleDevice.kt
@@ -116,7 +116,6 @@ internal class GaugeBleDevice(
         }
 
     private var observeGaugeStatusCallback: (suspend (status: GaugeStatus) -> Unit)? = null
-    private var logResponseCallback: (suspend (status: NodeReadGaugeLogsResponse) -> Unit)? = null
 
     // connection management
     override fun connect() = uart.connect()
@@ -208,19 +207,9 @@ internal class GaugeBleDevice(
         }
     }
 
-    private suspend fun handleLogResponse(message: NodeReadGaugeLogsResponse) {
-        logResponseCallback?.invoke(message)
-    }
-
     override suspend fun processNodeResponse(response: NodeResponse): Boolean {
-        return when (response) {
-            is NodeReadGaugeLogsResponse -> {
-                handleLogResponse(response)
-                true
-            }
-
-            else -> false
-        }
+        // nothing currently supported
+        return false
     }
 
     override fun sendSetHighLowAlarmStatus(
@@ -239,13 +228,15 @@ internal class GaugeBleDevice(
     override fun sendGaugeLogRequest(
         minSequence: UInt,
         maxSequence: UInt,
-        callback: (suspend (NodeReadGaugeLogsResponse) -> Unit)?,
+        reqId: UInt?,
+        callback: suspend (NodeReadGaugeLogsResponse) -> Unit,
     ) {
-        this.logResponseCallback = callback
         nodeParent.sendGaugeLogRequest(
             serialNumber,
             minSequence,
             maxSequence,
+            reqId,
+            callback,
         )
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedGaugeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedGaugeBleDevice.kt
@@ -273,7 +273,8 @@ internal class SimulatedGaugeBleDevice(
     override fun sendGaugeLogRequest(
         minSequence: UInt,
         maxSequence: UInt,
-        callback: (suspend (NodeReadGaugeLogsResponse) -> Unit)?
+        reqId: UInt?,
+        callback: suspend (NodeReadGaugeLogsResponse) -> Unit,
     ) {
         // do nothing
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartCapableGauge.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartCapableGauge.kt
@@ -45,6 +45,7 @@ internal interface UartCapableGauge : UartCapableSpecializedDevice {
     fun sendGaugeLogRequest(
         minSequence: UInt,
         maxSequence: UInt,
-        callback: (suspend (NodeReadGaugeLogsResponse) -> Unit)?,
+        reqId: UInt?,
+        callback: suspend (NodeReadGaugeLogsResponse) -> Unit,
     )
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadGaugeLogsResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeReadGaugeLogsResponse.kt
@@ -79,13 +79,18 @@ internal class NodeReadGaugeLogsResponse(
 
             val serialNumber = payload.getUtf8SerialNumber(SERIAL_NUMBER_IDX)
             val sequenceNumber = payload.getLittleEndianUInt32At(SEQ_NUMBER_IDX)
-            val temperature = SensorTemperature.fromRawDataStart(
-                payload.sliceArray(RAW_TEMP_IDX until (RAW_TEMP_IDX + RAW_TEMP_LENGTH))
-            )
             val isSensorPresent =
                 payload.sliceArray(
                     SENSOR_PRESENT_IDX until (SENSOR_PRESENT_IDX + SENSOR_PRESENT_LENGTH)
                 )[0].isBitSet(0)
+
+            val temperature = if (isSensorPresent) {
+                SensorTemperature.fromRawDataStart(
+                    payload.sliceArray(RAW_TEMP_IDX until (RAW_TEMP_IDX + RAW_TEMP_LENGTH))
+                )
+            } else {
+                SensorTemperature.NO_DATA
+            }
 
             return NodeReadGaugeLogsResponse(
                 serialNumber,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Gauge.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Gauge.kt
@@ -51,8 +51,6 @@ data class Gauge(
 ) : SpecializedDevice {
 
     companion object {
-        const val GAUGE_STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS = 15000L
-
         fun create(serialNumber: String = "", mac: String = ""): Gauge {
             return Gauge(
                 baseDevice = Device(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/Probe.kt
@@ -157,7 +157,6 @@ data class Probe(
         )
 
     companion object {
-        const val PROBE_STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS = 15000L
         const val PREDICTION_IDLE_TIMEOUT_MS = 60000L
 
         fun create(serialNumber: String = "", mac: String = "") : Probe {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/SensorTemperature.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/SensorTemperature.kt
@@ -52,6 +52,8 @@ value class SensorTemperature(
     }
 
     companion object {
+        val NO_DATA = SensorTemperature(-20.0)
+
         private fun UShort.temperatureFromRaw() =
             (this.toDouble() * 0.1) - 20.0
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
@@ -58,4 +58,8 @@ interface SpecializedDevice {
         get() = baseDevice.rssi
     val connectionState: DeviceConnectionState
         get() = baseDevice.connectionState
+
+    companion object {
+        const val STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS = 15000L
+    }
 }

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/service/SensorTemperatureTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/service/SensorTemperatureTest.kt
@@ -39,7 +39,7 @@ class SensorTemperatureTest {
 
     @Test
     @Parameters(method = "tempRawDataParams")
-    fun mew(givenTempValue: Double) {
+    fun `raw value is same as conversion from raw and then back to raw`(givenTempValue: Double) {
         val givenTemp = SensorTemperature(givenTempValue)
         assertEquals(SensorTemperature.fromRawDataEnd(givenTemp.toRawDataEnd()), givenTemp)
     }
@@ -48,4 +48,13 @@ class SensorTemperatureTest {
         arrayOf(-20.0),
         arrayOf(100.0)
     )
+
+    @Test
+    fun `verify no data bytes parses to no data value`() {
+        val tempFromRawDataStart = SensorTemperature.fromRawDataStart(UByteArray(2) { 0x0u })
+        assertEquals(-20.0, tempFromRawDataStart.value)
+
+        val tempFromRawDataEnd = SensorTemperature.fromRawDataEnd(UByteArray(2) { 0x0u })
+        assertEquals(-20.0, tempFromRawDataEnd.value)
+    }
 }


### PR DESCRIPTION
## Description
- Send gauge's setHighLowAlarmStatus and sendLogRequest calls to all connected meatnet nodes if directLink is not available.
- when gauge sensor not present then parse temperature as no data value

## Tech Notes
- `NetworkManager` now calls new `GaugeDataLinkArbitrator.addRepeaterNodes()`
- In `GaugeManager.setHighLowAlarmStatus()` and `GaugeManager.sendLogRequest()`, if `GaugeDataLinkArbitrator.directLink` is not available then message is sent to all `GaugeDataLinkArbitrator.connectedNodeLinks`