### PR TITLE
DROID-638 : fix Unknown device type crash when updating connected nodes

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/NodeBleDevice.kt
@@ -106,6 +106,10 @@ internal class NodeBleDevice(
         this.hybridDeviceChild = create(this)
     }
 
+    fun clearNodeHybridDevice() {
+        this.hybridDeviceChild = null
+    }
+
     fun sendNodeRequest(request: GenericNodeRequest, callback: ((Boolean, Any?) -> Unit)?) {
         val nodeRequest = request.toNodeRequest()
         genericRequestHandler.wait(


### PR DESCRIPTION
## Description
- Fix unknown device type crash when updating connected nodes

## Tech Notes
- unlinking gauge, which is a hybrid node device, removed reference to its node component (same mac) which is still "used" by devices

