### PR TITLE
DROID-687: App crash if access framework's service before it was initialized

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -43,11 +43,7 @@ import inc.combustion.framework.analytics.ExceptionEvent
 import inc.combustion.framework.ble.NetworkManager
 import inc.combustion.framework.ble.device.DeviceID
 import inc.combustion.framework.ble.dfu.DfuManager
-import inc.combustion.framework.ble.uart.meatnet.GenericNodeRequest
-import inc.combustion.framework.ble.uart.meatnet.GenericNodeResponse
-import inc.combustion.framework.ble.uart.meatnet.NodeMessage
-import inc.combustion.framework.ble.uart.meatnet.NodeMessageType
-import inc.combustion.framework.ble.uart.meatnet.NodeUARTMessage
+import inc.combustion.framework.ble.uart.meatnet.*
 import inc.combustion.framework.log.LogManager
 import inc.combustion.framework.service.DeviceManager.Companion.bindCombustionService
 import inc.combustion.framework.service.DeviceManager.Companion.startCombustionService
@@ -55,19 +51,8 @@ import inc.combustion.framework.service.DeviceManager.Companion.stopCombustionSe
 import inc.combustion.framework.service.DeviceManager.Companion.unbindCombustionService
 import inc.combustion.framework.service.dfu.DfuProductType
 import inc.combustion.framework.service.dfu.DfuSystemState
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Date
@@ -1018,13 +1003,13 @@ class DeviceManager(
      */
     val dfuDevices: Set<DeviceID>
         get() {
-            return serviceFlow?.value?.dfuManager?.availableDevices ?: setOf()
+            return serviceFlow.value?.dfuManager?.availableDevices ?: setOf()
         }
 
     /**
      * A flow exposing DFU status for a specific device.
      */
-    fun dfuFlowForDevice(id: DeviceID) = serviceFlow?.value?.dfuManager?.dfuFlowForDevice(id)
+    fun dfuFlowForDevice(id: DeviceID) = serviceFlow.value?.dfuManager?.dfuFlowForDevice(id)
 
     /**
      * Starts a DFU operation using the update file [updateFile] on the device associated with [id],


### PR DESCRIPTION
## Description
lateinit `DeviceManager.service` wont exist until service is initialized -- will throw exception if accessed before then

## Tech Notes
Implement `doWhenServiceInitialized` that will delay function on service (when service is not initialized) until service has been initialized - e.g. `startDfuMode()`

## Reproduce / Verify Fix
1. In device's Developer options enable "Don't keep activities" and set "Background process limit" to "No background processes"
2. launch Combustion app and navigate to "Update Devices" and move app to background
3. launch other apps
4. return to Combustion app that should still be on functioning "Update Devices" screen and not crashing