### PR TITLE
DROID-737: more ProbeID support

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/GaugeManager.kt
@@ -37,6 +37,7 @@ import inc.combustion.framework.service.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * This class is responsible for managing and arbitrating the data links to a gauge.
@@ -583,15 +584,14 @@ internal class GaugeManager(
         } ?: run {
             val nodeLinks = arbitrator.connectedNodeLinks
             if (nodeLinks.isNotEmpty()) {
-                var handled = false
+                val handled = AtomicBoolean(false)
                 nodeLinks.forEach { node ->
                     node.sendSetGaugeHighLowAlarmStatus(
                         serialNumber,
                         highLowAlarmStatus,
                         requestId,
                     ) { status, _ ->
-                        if (!handled) {
-                            handled = true
+                        if (!handled.getAndSet(true)) {
                             onCompletion(status)
                         }
                     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -53,10 +53,12 @@ import inc.combustion.framework.service.CombustionProductType.NODE
 import inc.combustion.framework.service.CombustionProductType.PROBE
 import inc.combustion.framework.service.utils.ConcurrentSnapshotMap
 import inc.combustion.framework.service.utils.plus
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
-import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.random.Random
 import kotlin.random.nextUInt
@@ -200,8 +202,7 @@ internal class NetworkManager(
         }
     }
 
-    private val knownProbeIdAssignedToDevice = ConcurrentHashMap<ProbeID, String>()
-    private val probeIdObservations = ConcurrentHashMap<String, Job>()
+    private val probeIdManager = ProbeIdManager(::setProbeID, scope)
 
     var deviceAllowlist: Set<String>? = settings.probeAllowlist
         private set
@@ -504,16 +505,7 @@ internal class NetworkManager(
         completionHandler: (Boolean) -> Unit,
     ) {
         Log.v(LOG_TAG, "setProbeID: assign $probeId to $serialNumber")
-        removeProbeIdAssignmentsToDevice(serialNumber, except = probeId)
-        val currentDeviceAssigned = knownProbeIdAssignedToDevice[probeId]
-        knownProbeIdAssignedToDevice[probeId] = serialNumber
-        if ((currentDeviceAssigned != null) && (currentDeviceAssigned != serialNumber)) {
-            Log.v(
-                LOG_TAG,
-                "setProbeID: assign $probeId to $serialNumber but currently assigned to $currentDeviceAssigned -- resolving"
-            )
-            avoidProbeIdConflict(currentDeviceAssigned, probeId)
-        }
+        probeIdManager.checkAndAvoidProbeIdConflictOnSetProbeId(serialNumber, probeId)
         probeManagers[serialNumber]?.setProbeID(probeId, completionHandler) ?: run {
             completionHandler(false)
         }
@@ -650,9 +642,7 @@ internal class NetworkManager(
     @ExperimentalCoroutinesApi
     fun clearDevices() {
         (probeManagers + gaugeManagers).forEach { (_, manager) -> manager.finish() }
-        knownProbeIdAssignedToDevice.clear()
-        probeIdObservations.values.toList().forEach { it.cancel() }
-        probeIdObservations.clear()
+        probeIdManager.clear()
         deviceInformationDevices.snapshot().forEach { (_, device) -> device.finish() }
         deviceInformationDevices.clear()
         probeManagers.clear()
@@ -773,129 +763,12 @@ internal class NetworkManager(
             probeManagers[probeSerialNumber] = manager
             LogManager.instance.manageProbe(scope, manager)
             wifiNodesManager.subscribeToNodeFlow(manager)
-
-            probeIdObservations[probeSerialNumber] = scope.launch {
-                manager.deviceFlow
-                    .filter {
-                        !it.isEmpty()
-                    }.map { it.id }
-                    .distinctUntilChanged()
-                    .collect { probeId ->
-                        Log.v(
-                            LOG_TAG,
-                            "Detect probeId $probeId is assigned to $probeSerialNumber"
-                        )
-                        removeProbeIdAssignmentsToDevice(probeSerialNumber, except = probeId)
-                        val currentDeviceForProbeId = knownProbeIdAssignedToDevice[probeId]
-                        if ((currentDeviceForProbeId != null) && (currentDeviceForProbeId != probeSerialNumber)) {
-                            resolveProbeIdConflict(
-                                newDeviceSerial = probeSerialNumber,
-                                currentDeviceSerial = currentDeviceForProbeId,
-                                conflictId = probeId,
-                            )
-                        } else {
-                            knownProbeIdAssignedToDevice[probeId] = probeSerialNumber
-                        }
-                    }
-            }
+            probeIdManager.addDevice(probeSerialNumber, manager)
 
             true
         } else {
             false
         }
-
-    private fun findLowestAvailableProbeId(exceptConflictId: ProbeID): ProbeID? {
-        return ProbeID.entries.firstOrNull {
-            (knownProbeIdAssignedToDevice[it] == null) && (it != exceptConflictId)
-        }
-    }
-
-    private fun removeProbeIdAssignmentsToDevice(serialNumber: String, except: ProbeID?) {
-        return ProbeID.entries.forEach {
-            if ((it != except) && (knownProbeIdAssignedToDevice[it] == serialNumber)) {
-                knownProbeIdAssignedToDevice.remove(it)
-            }
-        }
-    }
-
-    private fun resolveProbeIdConflict(
-        newDeviceSerial: String,
-        currentDeviceSerial: String,
-        conflictId: ProbeID,
-    ) {
-        val newNumeric = newDeviceSerial.toLongOrNull() ?: return
-        val currentNumeric = currentDeviceSerial.toLongOrNull() ?: return
-        val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
-
-        if (lowestAvailableProbeId == null) {
-            Log.v(
-                LOG_TAG,
-                "resolveProbeIdConflict: no available probeId found -- cancel resolving probeId conflict on $conflictId"
-            )
-            return
-        }
-
-        val (lowerProbeId, higherProbeId) = if (lowestAvailableProbeId < conflictId) {
-            Pair(lowestAvailableProbeId, conflictId)
-        } else {
-            Pair(conflictId, lowestAvailableProbeId)
-        }
-
-        // assign highest serialNumber to lowest ProbeId
-        val (newDeviceProbeId, currentDeviceProbeId) = if (newNumeric > currentNumeric) {
-            Pair(lowerProbeId, higherProbeId)
-        } else {
-            Pair(higherProbeId, lowerProbeId)
-        }
-
-        knownProbeIdAssignedToDevice[newDeviceProbeId] = newDeviceSerial
-        knownProbeIdAssignedToDevice[currentDeviceProbeId] = currentDeviceSerial
-        Log.v(
-            LOG_TAG,
-            "resolveProbeIdConflict: assign $newDeviceProbeId to $newDeviceSerial and $currentDeviceProbeId to $currentDeviceSerial",
-        )
-        setProbeID(newDeviceSerial, newDeviceProbeId) { success ->
-            if (!success) {
-                Log.v(
-                    LOG_TAG,
-                    "resolveProbeIdConflict: assign $newDeviceProbeId to $newDeviceSerial failed",
-                )
-            }
-        }
-        setProbeID(currentDeviceSerial, currentDeviceProbeId) { success ->
-            if (!success) {
-                Log.v(
-                    LOG_TAG,
-                    "resolveProbeIdConflict: assign $currentDeviceProbeId to $currentDeviceSerial failed",
-                )
-            }
-        }
-    }
-
-    private fun avoidProbeIdConflict(futureConflictDeviceId: String, conflictId: ProbeID) {
-        val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
-        // assign to lowest available probeId
-        if ((lowestAvailableProbeId != null) && (lowestAvailableProbeId != conflictId)) {
-            Log.v(
-                LOG_TAG,
-                "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceId"
-            )
-            knownProbeIdAssignedToDevice[lowestAvailableProbeId] = futureConflictDeviceId
-            setProbeID(futureConflictDeviceId, lowestAvailableProbeId) { success ->
-                if (!success) {
-                    Log.v(
-                        LOG_TAG,
-                        "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceId failed"
-                    )
-                }
-            }
-        } else {
-            Log.v(
-                LOG_TAG,
-                "avoidProbeIdConflict: No available ProbeId found to avoid future probeId conflict on $conflictId"
-            )
-        }
-    }
 
     /**
      * if we haven't seen [gaugeSerialNumber], then create a manager for it.
@@ -1227,8 +1100,7 @@ internal class NetworkManager(
 
         // Remove from probeId logic
         if (deviceManager is ProbeManager) {
-            probeIdObservations.remove(serialNumber)?.cancel()
-            removeProbeIdAssignmentsToDevice(serialNumber, except = null)
+            probeIdManager.removeDevice(serialNumber)
         }
 
         val deviceId = deviceManager?.device?.baseDevice?.id

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -53,12 +53,10 @@ import inc.combustion.framework.service.CombustionProductType.NODE
 import inc.combustion.framework.service.CombustionProductType.PROBE
 import inc.combustion.framework.service.utils.ConcurrentSnapshotMap
 import inc.combustion.framework.service.utils.plus
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.random.Random
 import kotlin.random.nextUInt
@@ -201,6 +199,9 @@ internal class NetworkManager(
             else -> NOT_IMPLEMENTED("getNodeDevice is not implemented for unknown device $node with id = $deviceId")
         }
     }
+
+    private val knownProbeIdAssignedToDevice = ConcurrentHashMap<ProbeID, String>()
+    private val probeIdObservations = ConcurrentHashMap<String, Job>()
 
     var deviceAllowlist: Set<String>? = settings.probeAllowlist
         private set
@@ -499,10 +500,21 @@ internal class NetworkManager(
 
     internal fun setProbeID(
         serialNumber: String,
-        id: ProbeID,
+        probeId: ProbeID,
         completionHandler: (Boolean) -> Unit,
     ) {
-        probeManagers[serialNumber]?.setProbeID(id, completionHandler) ?: run {
+        Log.v(LOG_TAG, "setProbeID: assign $probeId to $serialNumber")
+        removeProbeIdAssignmentsToDevice(serialNumber, except = probeId)
+        val currentDeviceAssigned = knownProbeIdAssignedToDevice[probeId]
+        knownProbeIdAssignedToDevice[probeId] = serialNumber
+        if ((currentDeviceAssigned != null) && (currentDeviceAssigned != serialNumber)) {
+            Log.v(
+                LOG_TAG,
+                "setProbeID: assign $probeId to $serialNumber but currently assigned to $currentDeviceAssigned -- resolving"
+            )
+            avoidProbeIdConflict(currentDeviceAssigned, probeId)
+        }
+        probeManagers[serialNumber]?.setProbeID(probeId, completionHandler) ?: run {
             completionHandler(false)
         }
     }
@@ -638,6 +650,9 @@ internal class NetworkManager(
     @ExperimentalCoroutinesApi
     fun clearDevices() {
         (probeManagers + gaugeManagers).forEach { (_, manager) -> manager.finish() }
+        knownProbeIdAssignedToDevice.clear()
+        probeIdObservations.values.toList().forEach { it.cancel() }
+        probeIdObservations.clear()
         deviceInformationDevices.snapshot().forEach { (_, device) -> device.finish() }
         deviceInformationDevices.clear()
         probeManagers.clear()
@@ -757,12 +772,130 @@ internal class NetworkManager(
 
             probeManagers[probeSerialNumber] = manager
             LogManager.instance.manageProbe(scope, manager)
-
             wifiNodesManager.subscribeToNodeFlow(manager)
+
+            probeIdObservations[probeSerialNumber] = scope.launch {
+                manager.deviceFlow
+                    .filter {
+                        !it.isEmpty()
+                    }.map { it.id }
+                    .distinctUntilChanged()
+                    .collect { probeId ->
+                        Log.v(
+                            LOG_TAG,
+                            "Detect probeId $probeId is assigned to $probeSerialNumber"
+                        )
+                        removeProbeIdAssignmentsToDevice(probeSerialNumber, except = probeId)
+                        val currentDeviceForProbeId = knownProbeIdAssignedToDevice[probeId]
+                        if ((currentDeviceForProbeId != null) && (currentDeviceForProbeId != probeSerialNumber)) {
+                            resolveProbeIdConflict(
+                                newDeviceSerial = probeSerialNumber,
+                                currentDeviceSerial = currentDeviceForProbeId,
+                                conflictId = probeId,
+                            )
+                        } else {
+                            knownProbeIdAssignedToDevice[probeId] = probeSerialNumber
+                        }
+                    }
+            }
+
             true
         } else {
             false
         }
+
+    private fun findLowestAvailableProbeId(exceptConflictId: ProbeID): ProbeID? {
+        return ProbeID.entries.firstOrNull {
+            (knownProbeIdAssignedToDevice[it] == null) && (it != exceptConflictId)
+        }
+    }
+
+    private fun removeProbeIdAssignmentsToDevice(serialNumber: String, except: ProbeID?) {
+        return ProbeID.entries.forEach {
+            if ((it != except) && (knownProbeIdAssignedToDevice[it] == serialNumber)) {
+                knownProbeIdAssignedToDevice.remove(it)
+            }
+        }
+    }
+
+    private fun resolveProbeIdConflict(
+        newDeviceSerial: String,
+        currentDeviceSerial: String,
+        conflictId: ProbeID,
+    ) {
+        val newNumeric = newDeviceSerial.toLongOrNull() ?: return
+        val currentNumeric = currentDeviceSerial.toLongOrNull() ?: return
+        val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
+
+        if (lowestAvailableProbeId == null) {
+            Log.v(
+                LOG_TAG,
+                "resolveProbeIdConflict: no available probeId found -- cancel resolving probeId conflict on $conflictId"
+            )
+            return
+        }
+
+        val (lowerProbeId, higherProbeId) = if (lowestAvailableProbeId < conflictId) {
+            Pair(lowestAvailableProbeId, conflictId)
+        } else {
+            Pair(conflictId, lowestAvailableProbeId)
+        }
+
+        // assign highest serialNumber to lowest ProbeId
+        val (newDeviceProbeId, currentDeviceProbeId) = if (newNumeric > currentNumeric) {
+            Pair(lowerProbeId, higherProbeId)
+        } else {
+            Pair(higherProbeId, lowerProbeId)
+        }
+
+        knownProbeIdAssignedToDevice[newDeviceProbeId] = newDeviceSerial
+        knownProbeIdAssignedToDevice[currentDeviceProbeId] = currentDeviceSerial
+        Log.v(
+            LOG_TAG,
+            "resolveProbeIdConflict: assign $newDeviceProbeId to $newDeviceSerial and $currentDeviceProbeId to $currentDeviceSerial",
+        )
+        setProbeID(newDeviceSerial, newDeviceProbeId) { success ->
+            if (!success) {
+                Log.v(
+                    LOG_TAG,
+                    "resolveProbeIdConflict: assign $newDeviceProbeId to $newDeviceSerial failed",
+                )
+            }
+        }
+        setProbeID(currentDeviceSerial, currentDeviceProbeId) { success ->
+            if (!success) {
+                Log.v(
+                    LOG_TAG,
+                    "resolveProbeIdConflict: assign $currentDeviceProbeId to $currentDeviceSerial failed",
+                )
+            }
+        }
+    }
+
+    private fun avoidProbeIdConflict(futureConflictDeviceId: String, conflictId: ProbeID) {
+        val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
+        // assign to lowest available probeId
+        if ((lowestAvailableProbeId != null) && (lowestAvailableProbeId != conflictId)) {
+            Log.v(
+                LOG_TAG,
+                "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceId"
+            )
+            knownProbeIdAssignedToDevice[lowestAvailableProbeId] = futureConflictDeviceId
+            setProbeID(futureConflictDeviceId, lowestAvailableProbeId) { success ->
+                if (!success) {
+                    Log.v(
+                        LOG_TAG,
+                        "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceId failed"
+                    )
+                }
+            }
+        } else {
+            Log.v(
+                LOG_TAG,
+                "avoidProbeIdConflict: No available ProbeId found to avoid future probeId conflict on $conflictId"
+            )
+        }
+    }
 
     /**
      * if we haven't seen [gaugeSerialNumber], then create a manager for it.
@@ -1089,8 +1222,14 @@ internal class NetworkManager(
     private fun unlinkDevice(serialNumber: String) {
         Log.i(LOG_TAG, "Unlinking device: $serialNumber")
 
-        // Remove the device from the discovere devices list
+        // Remove the device from the discovered devices list
         val deviceManager = probeManagers.remove(serialNumber) ?: gaugeManagers.remove(serialNumber)
+
+        // Remove from probeId logic
+        if (deviceManager is ProbeManager) {
+            probeIdObservations.remove(serialNumber)?.cancel()
+            removeProbeIdAssignmentsToDevice(serialNumber, except = null)
+        }
 
         val deviceId = deviceManager?.device?.baseDevice?.id
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
@@ -157,7 +157,7 @@ internal class ProbeIdManager(
         probeIdObservations[probeSerialNumber] = scope.launch {
             manager.deviceFlow
                 .filter {
-                    !it.isEmpty()
+                    !it.isPlaceholder()
                 }.map { it.id }
                 .distinctUntilChanged()
                 .collect { probeId ->

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
@@ -61,19 +61,19 @@ internal class ProbeIdManager(
         }
     }
 
-    fun resolveProbeIdConflict(
+    private fun resolveProbeIdConflict(
         newDeviceSerial: String,
         currentDeviceSerial: String,
         conflictId: ProbeID,
     ) {
-        val newNumeric = newDeviceSerial.toLongOrNull() ?: return
-        val currentNumeric = currentDeviceSerial.toLongOrNull() ?: return
+        val newNumeric = newDeviceSerial.toLongOrNull(16) ?: return
+        val currentNumeric = currentDeviceSerial.toLongOrNull(16) ?: return
         val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
 
         if (lowestAvailableProbeId == null) {
             Log.v(
                 LOG_TAG,
-                "resolveProbeIdConflict: no available probeId found -- cancel resolving probeId conflict on $conflictId"
+                "resolveProbeIdConflict: no available probeId found -- cancel resolving probeId conflict on $conflictId",
             )
             return
         }
@@ -99,6 +99,10 @@ internal class ProbeIdManager(
         )
         setProbeID(newDeviceSerial, newDeviceProbeId) { success ->
             if (!success) {
+                // revert change
+                if (knownProbeIdAssignedToDevice[newDeviceProbeId] == newDeviceSerial) {
+                    knownProbeIdAssignedToDevice.remove(newDeviceProbeId)
+                }
                 Log.v(
                     LOG_TAG,
                     "resolveProbeIdConflict: assign $newDeviceProbeId to $newDeviceSerial failed",
@@ -107,6 +111,10 @@ internal class ProbeIdManager(
         }
         setProbeID(currentDeviceSerial, currentDeviceProbeId) { success ->
             if (!success) {
+                // revert change
+                if (knownProbeIdAssignedToDevice[currentDeviceProbeId] == currentDeviceSerial) {
+                    knownProbeIdAssignedToDevice.remove(currentDeviceProbeId)
+                }
                 Log.v(
                     LOG_TAG,
                     "resolveProbeIdConflict: assign $currentDeviceProbeId to $currentDeviceSerial failed",
@@ -115,20 +123,24 @@ internal class ProbeIdManager(
         }
     }
 
-    private fun avoidProbeIdConflict(futureConflictDeviceId: String, conflictId: ProbeID) {
+    private fun avoidProbeIdConflict(futureConflictDeviceSerial: String, conflictId: ProbeID) {
         val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
         // assign to lowest available probeId
         if ((lowestAvailableProbeId != null) && (lowestAvailableProbeId != conflictId)) {
             Log.v(
                 LOG_TAG,
-                "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceId"
+                "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceSerial"
             )
-            knownProbeIdAssignedToDevice[lowestAvailableProbeId] = futureConflictDeviceId
-            setProbeID(futureConflictDeviceId, lowestAvailableProbeId) { success ->
+            knownProbeIdAssignedToDevice[lowestAvailableProbeId] = futureConflictDeviceSerial
+            setProbeID(futureConflictDeviceSerial, lowestAvailableProbeId) { success ->
                 if (!success) {
+                    // revert change
+                    if (knownProbeIdAssignedToDevice[lowestAvailableProbeId] == futureConflictDeviceSerial) {
+                        knownProbeIdAssignedToDevice.remove(lowestAvailableProbeId)
+                    }
                     Log.v(
                         LOG_TAG,
-                        "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceId failed"
+                        "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceSerial failed"
                     )
                 }
             }
@@ -168,6 +180,10 @@ internal class ProbeIdManager(
                     removeProbeIdAssignmentsToDevice(probeSerialNumber, except = probeId)
                     val currentDeviceForProbeId = knownProbeIdAssignedToDevice[probeId]
                     if ((currentDeviceForProbeId != null) && (currentDeviceForProbeId != probeSerialNumber)) {
+                        Log.v(
+                            LOG_TAG,
+                            "Conflict on probeId $probeId: $probeSerialNumber and $currentDeviceForProbeId",
+                        )
                         resolveProbeIdConflict(
                             newDeviceSerial = probeSerialNumber,
                             currentDeviceSerial = currentDeviceForProbeId,
@@ -190,5 +206,6 @@ internal class ProbeIdManager(
         Log.v(LOG_TAG, "clear")
         probeIdObservations.values.toList().forEach { it.cancel() }
         probeIdObservations.clear()
+        knownProbeIdAssignedToDevice.clear()
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
@@ -1,0 +1,194 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: ProbeIdManager.kt
+ * Author:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2026. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.ble
+
+import android.util.Log
+import inc.combustion.framework.service.ProbeID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+
+private const val LOG_TAG = "ProbeIdManager"
+
+internal class ProbeIdManager(
+    private val setProbeID: (serialNumber: String, probeId: ProbeID, completionHandler: (Boolean) -> Unit) -> Unit,
+    private val scope: CoroutineScope,
+    private val knownProbeIdAssignedToDevice: ConcurrentHashMap<ProbeID, String> = ConcurrentHashMap<ProbeID, String>(),
+) {
+    private val probeIdObservations = ConcurrentHashMap<String, Job>()
+
+    private fun findLowestAvailableProbeId(exceptConflictId: ProbeID): ProbeID? {
+        return ProbeID.entries.firstOrNull {
+            (knownProbeIdAssignedToDevice[it] == null) && (it != exceptConflictId)
+        }
+    }
+
+    private fun removeProbeIdAssignmentsToDevice(serialNumber: String, except: ProbeID?) {
+        return ProbeID.entries.forEach {
+            if ((it != except) && (knownProbeIdAssignedToDevice[it] == serialNumber)) {
+                knownProbeIdAssignedToDevice.remove(it)
+            }
+        }
+    }
+
+    fun resolveProbeIdConflict(
+        newDeviceSerial: String,
+        currentDeviceSerial: String,
+        conflictId: ProbeID,
+    ) {
+        val newNumeric = newDeviceSerial.toLongOrNull() ?: return
+        val currentNumeric = currentDeviceSerial.toLongOrNull() ?: return
+        val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
+
+        if (lowestAvailableProbeId == null) {
+            Log.v(
+                LOG_TAG,
+                "resolveProbeIdConflict: no available probeId found -- cancel resolving probeId conflict on $conflictId"
+            )
+            return
+        }
+
+        val (lowerProbeId, higherProbeId) = if (lowestAvailableProbeId < conflictId) {
+            Pair(lowestAvailableProbeId, conflictId)
+        } else {
+            Pair(conflictId, lowestAvailableProbeId)
+        }
+
+        // assign highest serialNumber to lowest ProbeId
+        val (newDeviceProbeId, currentDeviceProbeId) = if (newNumeric > currentNumeric) {
+            Pair(lowerProbeId, higherProbeId)
+        } else {
+            Pair(higherProbeId, lowerProbeId)
+        }
+
+        knownProbeIdAssignedToDevice[newDeviceProbeId] = newDeviceSerial
+        knownProbeIdAssignedToDevice[currentDeviceProbeId] = currentDeviceSerial
+        Log.v(
+            LOG_TAG,
+            "resolveProbeIdConflict: assign $newDeviceProbeId to $newDeviceSerial and $currentDeviceProbeId to $currentDeviceSerial",
+        )
+        setProbeID(newDeviceSerial, newDeviceProbeId) { success ->
+            if (!success) {
+                Log.v(
+                    LOG_TAG,
+                    "resolveProbeIdConflict: assign $newDeviceProbeId to $newDeviceSerial failed",
+                )
+            }
+        }
+        setProbeID(currentDeviceSerial, currentDeviceProbeId) { success ->
+            if (!success) {
+                Log.v(
+                    LOG_TAG,
+                    "resolveProbeIdConflict: assign $currentDeviceProbeId to $currentDeviceSerial failed",
+                )
+            }
+        }
+    }
+
+    private fun avoidProbeIdConflict(futureConflictDeviceId: String, conflictId: ProbeID) {
+        val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
+        // assign to lowest available probeId
+        if ((lowestAvailableProbeId != null) && (lowestAvailableProbeId != conflictId)) {
+            Log.v(
+                LOG_TAG,
+                "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceId"
+            )
+            knownProbeIdAssignedToDevice[lowestAvailableProbeId] = futureConflictDeviceId
+            setProbeID(futureConflictDeviceId, lowestAvailableProbeId) { success ->
+                if (!success) {
+                    Log.v(
+                        LOG_TAG,
+                        "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceId failed"
+                    )
+                }
+            }
+        } else {
+            Log.v(
+                LOG_TAG,
+                "avoidProbeIdConflict: No available ProbeId found to avoid future probeId conflict on $conflictId"
+            )
+        }
+    }
+
+    fun checkAndAvoidProbeIdConflictOnSetProbeId(serialNumber: String, probeId: ProbeID) {
+        removeProbeIdAssignmentsToDevice(serialNumber, except = probeId)
+        val currentDeviceAssigned = knownProbeIdAssignedToDevice[probeId]
+        knownProbeIdAssignedToDevice[probeId] = serialNumber
+        if ((currentDeviceAssigned != null) && (currentDeviceAssigned != serialNumber)) {
+            Log.v(
+                LOG_TAG,
+                "setProbeID: assign $probeId to $serialNumber but currently assigned to $currentDeviceAssigned -- resolving"
+            )
+            avoidProbeIdConflict(currentDeviceAssigned, probeId)
+        }
+    }
+
+    fun addDevice(probeSerialNumber: String, manager: ProbeManager) {
+        probeIdObservations[probeSerialNumber] = scope.launch {
+            manager.deviceFlow
+                .filter {
+                    !it.isEmpty()
+                }.map { it.id }
+                .distinctUntilChanged()
+                .collect { probeId ->
+                    Log.v(
+                        LOG_TAG,
+                        "Detect probeId $probeId is assigned to $probeSerialNumber"
+                    )
+                    removeProbeIdAssignmentsToDevice(probeSerialNumber, except = probeId)
+                    val currentDeviceForProbeId = knownProbeIdAssignedToDevice[probeId]
+                    if ((currentDeviceForProbeId != null) && (currentDeviceForProbeId != probeSerialNumber)) {
+                        resolveProbeIdConflict(
+                            newDeviceSerial = probeSerialNumber,
+                            currentDeviceSerial = currentDeviceForProbeId,
+                            conflictId = probeId,
+                        )
+                    } else {
+                        knownProbeIdAssignedToDevice[probeId] = probeSerialNumber
+                    }
+                }
+        }
+    }
+
+    fun removeDevice(serialNumber: String) {
+        Log.v(LOG_TAG, "removeDevice $serialNumber")
+        probeIdObservations.remove(serialNumber)?.cancel()
+        removeProbeIdAssignmentsToDevice(serialNumber, except = null)
+    }
+
+    fun clear() {
+        Log.v(LOG_TAG, "clear")
+        probeIdObservations.values.toList().forEach { it.cancel() }
+        probeIdObservations.clear()
+    }
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -399,15 +399,30 @@ internal class ProbeManager(
         }
     }
 
-    fun setProbeID(id: ProbeID, completionHandler: (Boolean) -> Unit) {
-        simulatedProbe?.sendSetProbeID(id) { status, _ ->
+    fun setProbeID(probeId: ProbeID, completionHandler: (Boolean) -> Unit) {
+        simulatedProbe?.sendSetProbeID(probeId) { status, _ ->
             completionHandler(status)
         } ?: run {
             // Note: not supported by MeatNet
-            arbitrator.directLink?.sendSetProbeID(id) { status, _ ->
+            arbitrator.directLink?.sendSetProbeID(probeId) { status, _ ->
                 completionHandler(status)
             } ?: run {
-                completionHandler(false)
+                val nodeLinks = arbitrator.connectedNodeLinks
+                if (nodeLinks.isNotEmpty()) {
+                    var handled = false
+                    val requestId = makeRequestId()
+                    nodeLinks.forEach {
+                        it.sendSetProbeID(probeId = probeId, requestId) { status, _ ->
+                            if (!handled) {
+                                handled = true
+                                completionHandler(status)
+                            }
+                        }
+                    }
+
+                } else {
+                    completionHandler(false)
+                }
             }
         }
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -400,12 +400,23 @@ internal class ProbeManager(
     }
 
     fun setProbeID(probeId: ProbeID, completionHandler: (Boolean) -> Unit) {
+        val onCompletion: (Boolean) -> Unit = { success ->
+            if (success) {
+                _deviceFlow.update {
+                    it.copy(
+                        id = probeId,
+                    )
+                }
+            }
+            completionHandler(success)
+        }
+
         simulatedProbe?.sendSetProbeID(probeId) { status, _ ->
-            completionHandler(status)
+            onCompletion(status)
         } ?: run {
             // Note: not supported by MeatNet
             arbitrator.directLink?.sendSetProbeID(probeId) { status, _ ->
-                completionHandler(status)
+                onCompletion(status)
             } ?: run {
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
@@ -415,13 +426,13 @@ internal class ProbeManager(
                         it.sendSetProbeID(probeId = probeId, requestId) { status, _ ->
                             if (!handled) {
                                 handled = true
-                                completionHandler(status)
+                                onCompletion(status)
                             }
                         }
                     }
 
                 } else {
-                    completionHandler(false)
+                    onCompletion(false)
                 }
             }
         }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -39,6 +39,7 @@ import inc.combustion.framework.service.utils.PredictionManager
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * This class is responsible for managing and arbitrating the data links to a temperature
@@ -414,18 +415,16 @@ internal class ProbeManager(
         simulatedProbe?.sendSetProbeID(probeId) { status, _ ->
             onCompletion(status)
         } ?: run {
-            // Note: not supported by MeatNet
             arbitrator.directLink?.sendSetProbeID(probeId) { status, _ ->
                 onCompletion(status)
             } ?: run {
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
                     nodeLinks.forEach {
                         it.sendSetProbeID(probeId = probeId, requestId) { status, _ ->
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 onCompletion(status)
                             }
                         }
@@ -452,12 +451,11 @@ internal class ProbeManager(
             } ?: run {
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
                     nodeLinks.forEach {
                         it.sendSetPrediction(removalTemperatureC, mode, requestId) { status, _ ->
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 completionHandler(status)
                             }
                         }
@@ -480,12 +478,11 @@ internal class ProbeManager(
             } ?: run {
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
                     nodeLinks.forEach {
                         it.sendConfigureFoodSafe(foodSafeData, requestId) { status, _ ->
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 completionHandler(status)
                             }
                         }
@@ -508,12 +505,11 @@ internal class ProbeManager(
             } ?: run {
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
                     nodeLinks.forEach {
                         it.sendResetFoodSafe(requestId) { status, _ ->
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 completionHandler(status)
                             }
                         }
@@ -549,12 +545,11 @@ internal class ProbeManager(
             } ?: run {
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
                     nodeLinks.forEach {
                         it.sendSetPowerMode(powerMode, requestId) { status, _ ->
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 onCompletion(status)
                             }
                         }
@@ -577,12 +572,11 @@ internal class ProbeManager(
             } ?: run {
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
                     nodeLinks.forEach {
                         it.sendResetProbe(requestId) { status, _ ->
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 completionHandler(status)
                             }
                         }
@@ -619,14 +613,13 @@ internal class ProbeManager(
             } ?: run {
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     nodeLinks.forEach { node ->
                         node.sendSetProbeHighLowAlarmStatus(
                             probeHighLowAlarmStatus,
                             requestId,
                         ) { status, _ ->
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 onCompletion(status)
                             }
                         }
@@ -902,7 +895,7 @@ internal class ProbeManager(
                 // otherwise, use MeatNet is there is a connection
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
 
                     // for each MeatNet link, send the request
@@ -910,8 +903,7 @@ internal class ProbeManager(
                         device.readProbeFirmwareVersion(requestId) { version ->
 
                             // on first response from network, use the value
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 _deviceFlow.update {
                                     it.copy(baseDevice = it.baseDevice.copy(fwVersion = version))
                                 }
@@ -939,7 +931,7 @@ internal class ProbeManager(
                 // otherwise, use MeatNet is there is a connection
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
 
                     // for each MeatNet link, send the request
@@ -947,8 +939,7 @@ internal class ProbeManager(
                         device.readProbeHardwareRevision(requestId) { revision ->
 
                             // on first response from network, use the value
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 _deviceFlow.update {
                                     it.copy(
                                         baseDevice = it.baseDevice.copy(hwRevision = revision)
@@ -980,7 +971,7 @@ internal class ProbeManager(
                 // otherwise, use MeatNet is there is a connection
                 val nodeLinks = arbitrator.connectedNodeLinks
                 if (nodeLinks.isNotEmpty()) {
-                    var handled = false
+                    val handled = AtomicBoolean(false)
                     val requestId = makeRequestId()
 
                     // for each MeatNet link, send the request
@@ -988,8 +979,7 @@ internal class ProbeManager(
                         device.readProbeModelInformation(requestId) { info ->
 
                             // on first response from network, use the value
-                            if (!handled) {
-                                handled = true
+                            if (!handled.getAndSet(true)) {
                                 _deviceFlow.update {
                                     it.copy(baseDevice = it.baseDevice.copy(modelInformation = info))
                                 }
@@ -1018,13 +1008,12 @@ internal class ProbeManager(
                     // otherwise, use MeatNet is there is a connection
                     val nodeLinks = arbitrator.connectedNodeLinks
                     if (nodeLinks.isNotEmpty()) {
-                        var handled = false
+                        val handled = AtomicBoolean(false)
                         val requestId = makeRequestId()
                         nodeLinks.forEach {
                             it.sendSessionInformationRequest(requestId) { b, any ->
                                 // on first response from network, use the value
-                                if (!handled) {
-                                    handled = true
+                                if (!handled.getAndSet(true)) {
                                     nodeLinks.forEach { link ->
                                         if (link != it) {
                                             link.cancelSessionInfoRequest(requestId)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/ProbeBleDevice.kt
@@ -170,9 +170,9 @@ internal class ProbeBleDevice(
         sendUartRequest(SetColorRequest(color))
     }
 
-    override fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)?) {
+    override fun sendSetProbeID(probeId: ProbeID, reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
         setIdHandler.wait(uart.scope, PROBE_MESSAGE_RESPONSE_TIMEOUT_MS, null, callback)
-        sendUartRequest(SetIDRequest(id))
+        sendUartRequest(SetProbeIDRequest(probeId))
     }
 
     override fun sendSetPrediction(
@@ -383,7 +383,7 @@ internal class ProbeBleDevice(
                     )
 
                     is SetColorResponse -> setColorHandler.handled(response.success, null)
-                    is SetIDResponse -> setIdHandler.handled(response.success, null)
+                    is SetProbeIDResponse -> setIdHandler.handled(response.success, null)
                     is SetPredictionResponse -> setPredictionHandler.handled(response.success, null)
                     is ConfigureFoodSafeResponse -> configureFoodSafeHandler.handled(
                         response.success,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
@@ -40,12 +40,7 @@ import inc.combustion.framework.ble.scanning.ProbeAdvertisingData
 import inc.combustion.framework.ble.uart.ProbeLogResponse
 import inc.combustion.framework.ble.uart.meatnet.*
 import inc.combustion.framework.service.*
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 
 /**
  * Class representing a probe connected through one or more MeatNet nodes.
@@ -219,7 +214,11 @@ internal class RepeatedProbeBleDevice(
         NOT_IMPLEMENTED("Not able to set probe color over MeatNet")
     }
 
-    override fun sendSetProbeID(probeId: ProbeID, reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
+    override fun sendSetProbeID(
+        probeId: ProbeID,
+        reqId: UInt?,
+        callback: ((Boolean, Any?) -> Unit)?
+    ) {
         setIdHandler.wait(uart.scope, MEATNET_MESSAGE_RESPONSE_TIMEOUT_MS, reqId, callback)
         sendUartRequest(NodeSetProbeIDRequest(serialNumber, probeId, reqId))
     }
@@ -585,6 +584,10 @@ internal class RepeatedProbeBleDevice(
                     }
 
                     // Synchronous Requests that are responded to with a single message
+                    is NodeSetProbeIDResponse -> {
+                        setIdHandler.handled(message.success, null, message.requestId)
+                    }
+
                     is NodeSetPredictionResponse -> {
                         setPredictionHandler.handled(message.success, null, message.requestId)
                     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/RepeatedProbeBleDevice.kt
@@ -219,8 +219,9 @@ internal class RepeatedProbeBleDevice(
         NOT_IMPLEMENTED("Not able to set probe color over MeatNet")
     }
 
-    override fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)?) {
-        NOT_IMPLEMENTED("Not able to set probe ID over MeatNet")
+    override fun sendSetProbeID(probeId: ProbeID, reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
+        setIdHandler.wait(uart.scope, MEATNET_MESSAGE_RESPONSE_TIMEOUT_MS, reqId, callback)
+        sendUartRequest(NodeSetProbeIDRequest(serialNumber, probeId, reqId))
     }
 
     override fun sendSessionInformationRequest(reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/SimulatedProbeBleDevice.kt
@@ -292,8 +292,8 @@ internal class SimulatedProbeBleDevice(
         callback?.let { it(true, null) }
     }
 
-    override fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)?) {
-        probeID = id
+    override fun sendSetProbeID(probeId: ProbeID, reqId: UInt?, callback: ((Boolean, Any?) -> Unit)?) {
+        probeID = probeId
         callback?.let { it(true, null) }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartCapableProbe.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/device/UartCapableProbe.kt
@@ -31,12 +31,7 @@ package inc.combustion.framework.ble.device
 import inc.combustion.framework.ble.ProbeStatus
 import inc.combustion.framework.ble.scanning.ProbeAdvertisingData
 import inc.combustion.framework.ble.uart.ProbeLogResponse
-import inc.combustion.framework.service.FoodSafeData
-import inc.combustion.framework.service.ProbeColor
-import inc.combustion.framework.service.ProbeHighLowAlarmStatus
-import inc.combustion.framework.service.ProbeID
-import inc.combustion.framework.service.ProbePowerMode
-import inc.combustion.framework.service.ProbePredictionMode
+import inc.combustion.framework.service.*
 
 typealias LinkID = String
 
@@ -57,17 +52,54 @@ internal interface UartCapableProbe : UartCapableSpecializedDevice {
     val advertisement: ProbeAdvertisingData?
 
     // probe status updates
-    fun observeProbeStatusUpdates(hopCount: UInt?, callback: (suspend (status: ProbeStatus, hopCount: UInt?) -> Unit)? = null)
+    fun observeProbeStatusUpdates(
+        hopCount: UInt?,
+        callback: (suspend (status: ProbeStatus, hopCount: UInt?) -> Unit)? = null,
+    )
 
     // Probe UART Command APIs
-    fun sendSessionInformationRequest(reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)? = null)
+    fun sendSessionInformationRequest(
+        reqId: UInt? = null,
+        callback: ((Boolean, Any?) -> Unit)? = null,
+    )
+
     fun sendSetProbeColor(color: ProbeColor, callback: ((Boolean, Any?) -> Unit)? = null)
-    fun sendSetProbeID(id: ProbeID, callback: ((Boolean, Any?) -> Unit)? = null)
-    fun sendSetPrediction(setPointTemperatureC: Double, mode: ProbePredictionMode, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)? = null)
-    fun sendConfigureFoodSafe(foodSafeData: FoodSafeData, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)? = null)
+    fun sendSetProbeID(
+        probeId: ProbeID,
+        reqId: UInt? = null,
+        callback: ((Boolean, Any?) -> Unit)? = null,
+    )
+
+    fun sendSetPrediction(
+        setPointTemperatureC: Double,
+        mode: ProbePredictionMode,
+        reqId: UInt? = null,
+        callback: ((Boolean, Any?) -> Unit)? = null,
+    )
+
+    fun sendConfigureFoodSafe(
+        foodSafeData: FoodSafeData,
+        reqId: UInt? = null,
+        callback: ((Boolean, Any?) -> Unit)? = null,
+    )
+
     fun sendResetFoodSafe(reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)? = null)
-    fun sendLogRequest(minSequence: UInt, maxSequence: UInt, callback: (suspend (ProbeLogResponse) -> Unit)? = null)
-    fun sendSetPowerMode(powerMode: ProbePowerMode, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)?)
+    fun sendLogRequest(
+        minSequence: UInt,
+        maxSequence: UInt,
+        callback: (suspend (ProbeLogResponse) -> Unit)? = null,
+    )
+
+    fun sendSetPowerMode(
+        powerMode: ProbePowerMode,
+        reqId: UInt? = null,
+        callback: ((Boolean, Any?) -> Unit)?,
+    )
+
     fun sendResetProbe(reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)?)
-    fun sendSetProbeHighLowAlarmStatus(highLowAlarmStatus: ProbeHighLowAlarmStatus, reqId: UInt? = null, callback: ((Boolean, Any?) -> Unit)?)
+    fun sendSetProbeHighLowAlarmStatus(
+        highLowAlarmStatus: ProbeHighLowAlarmStatus,
+        reqId: UInt? = null,
+        callback: ((Boolean, Any?) -> Unit)?,
+    )
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/Response.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/Response.kt
@@ -107,9 +107,9 @@ internal open class Response(
 
                 MessageType.SET_PROBE_ID -> createGenericResponse(
                     success,
-                    SetIDResponse.PAYLOAD_LENGTH,
+                    SetProbeIDResponse.PAYLOAD_LENGTH,
                     length.toUInt(),
-                    ::SetIDResponse,
+                    ::SetProbeIDResponse,
                 )
 
                 MessageType.READ_SESSION_INFO -> SessionInfoResponse.fromData(

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SetProbeIDRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SetProbeIDRequest.kt
@@ -1,0 +1,46 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: SetID.kt
+ * Author: https://github.com/jjohnstz
+ *
+ * MIT License
+ *
+ * Copyright (c) 2022. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.ble.uart
+
+import inc.combustion.framework.service.ProbeID
+
+internal class SetProbeIDRequest(
+    id: ProbeID
+) : Request(PAYLOAD_LENGTH, MessageType.SET_PROBE_ID) {
+
+    companion object {
+        const val PAYLOAD_LENGTH: UByte = 1u
+    }
+
+    init {
+        data[(HEADER_SIZE).toInt()] = id.type
+
+        setCRC()
+    }
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SetProbeIDResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/SetProbeIDResponse.kt
@@ -27,7 +27,7 @@
  */
 package inc.combustion.framework.ble.uart
 
-internal class SetIDResponse (
+internal class SetProbeIDResponse (
     success: Boolean,
     payLoadLength: UInt
 ) : Response(success, payLoadLength) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeMessageType.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeMessageType.kt
@@ -38,7 +38,7 @@ interface NodeMessage {
  */
 internal enum class NodeMessageType(override val value: UByte) : NodeMessage {
 
-    SET_ID(0x1u),
+    SET_PROBE_ID(0x1u),
     SET_COLOR(0x2u),
     SESSION_INFO(0x3u),
     PROBE_LOG(0x4u),

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeResponse.kt
@@ -127,6 +127,16 @@ internal open class NodeResponse(
             }
 
             return when (messageType) {
+
+                NodeMessageType.SET_PROBE_ID -> {
+                    NodeSetProbeIDResponse.fromData(
+                        success,
+                        requestId,
+                        responseId,
+                        payloadLength
+                    )
+                }
+
                 NodeMessageType.PROBE_LOG -> {
                     NodeReadProbeLogsResponse.fromData(
                         data,

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetProbeIDRequest.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetProbeIDRequest.kt
@@ -1,11 +1,11 @@
 /*
  * Project: Combustion Inc. Android Framework
- * File: SetID.kt
- * Author: https://github.com/jjohnstz
+ * File: NodeSetProbeIdRequest.kt
+ * Author:
  *
  * MIT License
  *
- * Copyright (c) 2022. Combustion Inc.
+ * Copyright (c) 2026. Combustion Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,21 +26,45 @@
  * SOFTWARE.
  */
 
-package inc.combustion.framework.ble.uart
+package inc.combustion.framework.ble.uart.meatnet
 
+import inc.combustion.framework.ble.putLittleEndianUInt32At
 import inc.combustion.framework.service.ProbeID
 
-internal class SetIDRequest(
-    id: ProbeID
-) : Request(PAYLOAD_LENGTH, MessageType.SET_PROBE_ID) {
-
-    companion object {
-        const val PAYLOAD_LENGTH: UByte = 1u
+internal class NodeSetProbeIDRequest(
+    serialNumber: String,
+    private val probeId: ProbeID,
+    requestId: UInt? = null
+) : NodeRequest(
+    populatePayload(serialNumber, probeId),
+    NodeMessageType.SET_PROBE_ID,
+    requestId,
+    serialNumber,
+) {
+    override fun toString(): String {
+        return "${super.toString()} $serialNumber $probeId"
     }
 
-    init {
-        data[(HEADER_SIZE).toInt()] = id.type
+    companion object {
+        private const val PAYLOAD_LENGTH: UByte = 5u
 
-        setCRC()
+        /**
+         * Helper function that builds up payload of request.
+         */
+        fun populatePayload(
+            serialNumber: String,
+            probeId: ProbeID,
+        ): UByteArray {
+
+            val payload = UByteArray(PAYLOAD_LENGTH.toInt())
+
+            // Add serial number to payload
+            payload.putLittleEndianUInt32At(0, serialNumber.toLong(radix = 16).toUInt())
+
+            // Encode ID in payload
+            payload[4] = probeId.type
+
+            return payload
+        }
     }
 }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetProbeIDResponse.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/uart/meatnet/NodeSetProbeIDResponse.kt
@@ -1,0 +1,68 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: NodeSetProbeIdResponse.kt
+ * Author:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2026. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.ble.uart.meatnet
+
+internal class NodeSetProbeIDResponse(
+    success: Boolean,
+    requestId: UInt,
+    responseId: UInt,
+    payloadLength: UByte,
+) : NodeResponse(
+    success,
+    requestId,
+    responseId,
+    payloadLength,
+    NodeMessageType.SET_PROBE_ID,
+) {
+    override fun toString(): String {
+        return "${super.toString()} $success"
+    }
+
+    companion object {
+        private const val PAYLOAD_LENGTH: UByte = 0u
+
+        fun fromData(
+            success: Boolean,
+            requestId: UInt,
+            responseId: UInt,
+            payloadLength: UByte,
+        ): NodeSetProbeIDResponse? {
+            if (payloadLength < PAYLOAD_LENGTH) {
+                return null
+            }
+
+            return NodeSetProbeIDResponse(
+                success,
+                requestId,
+                responseId,
+                payloadLength
+            )
+        }
+    }
+}

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
@@ -60,7 +60,7 @@ interface SpecializedDevice {
         get() = baseDevice.connectionState
 
     /**
-     * Returns true if not an actual full valid state but still hase placeholder values
+     * Returns true if not an actual full valid state but still has placeholder values
      */
     fun isPlaceholder(): Boolean {
         return (maxSequence == null) && (sessionInfo == null)

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
@@ -60,9 +60,9 @@ interface SpecializedDevice {
         get() = baseDevice.connectionState
 
     /**
-     * Returns true if not an actual full state but still hase placeholder values
+     * Returns true if not an actual full valid state but still hase placeholder values
      */
-    fun isEmpty(): Boolean {
+    fun isPlaceholder(): Boolean {
         return (maxSequence == null) && (sessionInfo == null)
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/SpecializedDevice.kt
@@ -59,6 +59,13 @@ interface SpecializedDevice {
     val connectionState: DeviceConnectionState
         get() = baseDevice.connectionState
 
+    /**
+     * Returns true if not an actual full state but still hase placeholder values
+     */
+    fun isEmpty(): Boolean {
+        return (maxSequence == null) && (sessionInfo == null)
+    }
+
     companion object {
         const val STATUS_NOTIFICATIONS_IDLE_TIMEOUT_MS = 15000L
     }


### PR DESCRIPTION
## Description
- add Meatnet support for setting ProbeID
- add logic to prevent ProbeID conflict

## Tech Notes
- `NodeSetProbeIDRequest` and `NodeSetProbeIDResponse` do the meatnet send/receive
- `ProbeIdManager` performs the ID conflict logic