### PR TITLE
[PRO-132] Add high radio power bit to ThermometerPreferences

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/ThermometerPreferences.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/ThermometerPreferences.kt
@@ -28,15 +28,22 @@
 
 package inc.combustion.framework.service
 
-data class ThermometerPreferences(val powerMode: ProbePowerMode) {
+data class ThermometerPreferences(
+    val powerMode: ProbePowerMode,
+    val highRadioPower: Boolean = false,
+) {
 
     companion object {
         const val PROBE_PREFS_SIZE_BYTES = 1
 
-        val DEFAULT = ThermometerPreferences(powerMode = ProbePowerMode.NORMAL)
+        val DEFAULT = ThermometerPreferences(powerMode = ProbePowerMode.NORMAL, highRadioPower = false)
 
         fun fromUByte(byte: UByte): ThermometerPreferences {
-            return ThermometerPreferences(powerMode = ProbePowerMode.fromUByte(byte))
+            val highRadioPower = (byte.toInt() shr 2) and 0x1 != 0
+            return ThermometerPreferences(
+                powerMode = ProbePowerMode.fromUByte(byte),
+                highRadioPower = highRadioPower,
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `highRadioPower: Boolean` property to `ThermometerPreferences` data class, parsed from bit 2 of the preferences byte
- Updates `fromUByte()` to extract the new bit and `DEFAULT` to include `highRadioPower = false`
- No changes needed to `ProbePowerMode.kt` — the `0x03` mask correctly isolates bits 0-1

## Context
Corresponds to firmware PRO-132 which adds a high radio power status bit (bit 2) to the ThermometerPreferences BLE advertising byte. The Android BLE library exposes smoothed RSSI via flows without internal thresholding, so proximity threshold adjustments for high-power devices should be handled at the app layer using the new `highRadioPower` flag.

## Test plan
- [ ] Build Android BLE library successfully
- [ ] Run unit tests
- [ ] Connect to V2 probe with high power enabled — verify `highRadioPower` parses as `true`
- [ ] Connect to V1 probe — verify `highRadioPower` defaults to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)