### PR TITLE
DROID-746 : changes to setting ProbeID requirements

### DIFF
--- a/combustion-android-ble/build.gradle.kts
+++ b/combustion-android-ble/build.gradle.kts
@@ -49,6 +49,11 @@ android {
             useSupportLibrary = true
         }
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -113,6 +118,7 @@ dependencies {
     testImplementation(frameworkLibs.kotlin.test.junit)
     testImplementation(frameworkLibs.junit.params)
     testImplementation(frameworkLibs.mockk.android)
+    testImplementation(frameworkLibs.kotlinx.coroutines.test)
 }
 
 afterEvaluate {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -315,6 +315,8 @@ internal class NetworkManager(
     val silenceAlarmsRequestFlow: SharedFlow<SilenceAlarmsRequest>
         get() = _silenceAlarmsRequestFlow.asSharedFlow()
 
+    val availableProbeIDs: Flow<List<ProbeID>> = probeIdManager.availableProbeIds
+
     init {
         require(context.applicationContext === context) {
             "NetworkManager must be given application context"
@@ -505,9 +507,16 @@ internal class NetworkManager(
         completionHandler: (Boolean) -> Unit,
     ) {
         Log.v(LOG_TAG, "setProbeID: assign $probeId to $serialNumber")
-        probeIdManager.checkAndAvoidProbeIdConflictOnSetProbeId(serialNumber, probeId)
-        probeManagers[serialNumber]?.setProbeID(probeId, completionHandler) ?: run {
+        if (probeIdManager.hasProbeIdConflict(serialNumber, probeId)) {
+            Log.w(
+                LOG_TAG,
+                "setProbeID: unable to perform since there is an existing probe assigned to $probeId",
+            )
             completionHandler(false)
+        } else {
+            probeManagers[serialNumber]?.setProbeID(probeId, completionHandler) ?: run {
+                completionHandler(false)
+            }
         }
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -507,6 +507,10 @@ internal class NetworkManager(
         completionHandler: (Boolean) -> Unit,
     ) {
         scope.launch(Dispatchers.Main) {
+            // Serializes concurrent explicit setProbeID calls against each other's conflict check.
+            // Does NOT protect against the gap between dispatching the BLE write and the
+            // observation flow updating knownProbeIdAssignedToDevice; any collision that slips
+            // through that window is caught and resolved by ProbeIdManager.addDevice.
             setProbeIdLock.withLock {
                 Log.v(LOG_TAG, "setProbeID: assign $probeId to $serialNumber")
                 if (probeIdManager.hasProbeIdConflict(serialNumber, probeId)) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -53,15 +53,12 @@ import inc.combustion.framework.service.CombustionProductType.NODE
 import inc.combustion.framework.service.CombustionProductType.PROBE
 import inc.combustion.framework.service.utils.ConcurrentSnapshotMap
 import inc.combustion.framework.service.utils.plus
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 import kotlin.random.Random
 import kotlin.random.nextUInt
 
@@ -205,7 +202,7 @@ internal class NetworkManager(
     }
 
     private val probeIdManager = ProbeIdManager(::setProbeID, scope)
-    private val setProbeIdLock = ReentrantLock()
+    private val setProbeIdLock = Mutex()
 
     var deviceAllowlist: Set<String>? = settings.probeAllowlist
         private set
@@ -509,17 +506,19 @@ internal class NetworkManager(
         probeId: ProbeID,
         completionHandler: (Boolean) -> Unit,
     ) {
-        setProbeIdLock.withLock {
-            Log.v(LOG_TAG, "setProbeID: assign $probeId to $serialNumber")
-            if (probeIdManager.hasProbeIdConflict(serialNumber, probeId)) {
-                Log.w(
-                    LOG_TAG,
-                    "setProbeID: unable to perform since there is an existing probe assigned to $probeId",
-                )
-                completionHandler(false)
-            } else {
-                probeManagers[serialNumber]?.setProbeID(probeId, completionHandler)
-                    ?: completionHandler(false)
+        scope.launch(Dispatchers.Main) {
+            setProbeIdLock.withLock {
+                Log.v(LOG_TAG, "setProbeID: assign $probeId to $serialNumber")
+                if (probeIdManager.hasProbeIdConflict(serialNumber, probeId)) {
+                    Log.w(
+                        LOG_TAG,
+                        "setProbeID: unable to perform since there is an existing probe assigned to $probeId",
+                    )
+                    completionHandler(false)
+                } else {
+                    probeManagers[serialNumber]?.setProbeID(probeId, completionHandler)
+                        ?: completionHandler(false)
+                }
             }
         }
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/NetworkManager.kt
@@ -60,6 +60,8 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import kotlin.random.Random
 import kotlin.random.nextUInt
 
@@ -203,6 +205,7 @@ internal class NetworkManager(
     }
 
     private val probeIdManager = ProbeIdManager(::setProbeID, scope)
+    private val setProbeIdLock = ReentrantLock()
 
     var deviceAllowlist: Set<String>? = settings.probeAllowlist
         private set
@@ -315,7 +318,7 @@ internal class NetworkManager(
     val silenceAlarmsRequestFlow: SharedFlow<SilenceAlarmsRequest>
         get() = _silenceAlarmsRequestFlow.asSharedFlow()
 
-    val availableProbeIDs: Flow<List<ProbeID>> = probeIdManager.availableProbeIds
+    val availableProbeIDs: Flow<List<ProbeID>> = probeIdManager.availableProbeIDs
 
     init {
         require(context.applicationContext === context) {
@@ -506,16 +509,17 @@ internal class NetworkManager(
         probeId: ProbeID,
         completionHandler: (Boolean) -> Unit,
     ) {
-        Log.v(LOG_TAG, "setProbeID: assign $probeId to $serialNumber")
-        if (probeIdManager.hasProbeIdConflict(serialNumber, probeId)) {
-            Log.w(
-                LOG_TAG,
-                "setProbeID: unable to perform since there is an existing probe assigned to $probeId",
-            )
-            completionHandler(false)
-        } else {
-            probeManagers[serialNumber]?.setProbeID(probeId, completionHandler) ?: run {
+        setProbeIdLock.withLock {
+            Log.v(LOG_TAG, "setProbeID: assign $probeId to $serialNumber")
+            if (probeIdManager.hasProbeIdConflict(serialNumber, probeId)) {
+                Log.w(
+                    LOG_TAG,
+                    "setProbeID: unable to perform since there is an existing probe assigned to $probeId",
+                )
                 completionHandler(false)
+            } else {
+                probeManagers[serialNumber]?.setProbeID(probeId, completionHandler)
+                    ?: completionHandler(false)
             }
         }
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
@@ -30,11 +30,10 @@ package inc.combustion.framework.ble
 
 import android.util.Log
 import inc.combustion.framework.service.ProbeID
+import inc.combustion.framework.service.utils.StateFlowMutableMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 
@@ -43,9 +42,14 @@ private const val LOG_TAG = "ProbeIdManager"
 internal class ProbeIdManager(
     private val setProbeID: (serialNumber: String, probeId: ProbeID, completionHandler: (Boolean) -> Unit) -> Unit,
     private val scope: CoroutineScope,
-    private val knownProbeIdAssignedToDevice: ConcurrentHashMap<ProbeID, String> = ConcurrentHashMap<ProbeID, String>(),
+    private val knownProbeIdAssignedToDevice: StateFlowMutableMap<ProbeID, String> = StateFlowMutableMap(),
 ) {
     private val probeIdObservations = ConcurrentHashMap<String, Job>()
+
+    val availableProbeIds: Flow<List<ProbeID>> =
+        knownProbeIdAssignedToDevice.stateFlow.map { map ->
+            ProbeID.entries.filterNot { map.keys.contains(it) }
+        }
 
     private fun findLowestAvailableProbeId(exceptConflictId: ProbeID): ProbeID? {
         return ProbeID.entries.firstOrNull {
@@ -123,46 +127,9 @@ internal class ProbeIdManager(
         }
     }
 
-    private fun avoidProbeIdConflict(futureConflictDeviceSerial: String, conflictId: ProbeID) {
-        val lowestAvailableProbeId = findLowestAvailableProbeId(conflictId)
-        // assign to lowest available probeId
-        if ((lowestAvailableProbeId != null) && (lowestAvailableProbeId != conflictId)) {
-            Log.v(
-                LOG_TAG,
-                "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceSerial"
-            )
-            knownProbeIdAssignedToDevice[lowestAvailableProbeId] = futureConflictDeviceSerial
-            setProbeID(futureConflictDeviceSerial, lowestAvailableProbeId) { success ->
-                if (!success) {
-                    // revert change
-                    if (knownProbeIdAssignedToDevice[lowestAvailableProbeId] == futureConflictDeviceSerial) {
-                        knownProbeIdAssignedToDevice.remove(lowestAvailableProbeId)
-                    }
-                    Log.v(
-                        LOG_TAG,
-                        "avoidProbeIdConflict: assign $lowestAvailableProbeId to $futureConflictDeviceSerial failed"
-                    )
-                }
-            }
-        } else {
-            Log.v(
-                LOG_TAG,
-                "avoidProbeIdConflict: No available ProbeId found to avoid future probeId conflict on $conflictId"
-            )
-        }
-    }
-
-    fun checkAndAvoidProbeIdConflictOnSetProbeId(serialNumber: String, probeId: ProbeID) {
-        removeProbeIdAssignmentsToDevice(serialNumber, except = probeId)
-        val currentDeviceAssigned = knownProbeIdAssignedToDevice[probeId]
-        knownProbeIdAssignedToDevice[probeId] = serialNumber
-        if ((currentDeviceAssigned != null) && (currentDeviceAssigned != serialNumber)) {
-            Log.v(
-                LOG_TAG,
-                "setProbeID: assign $probeId to $serialNumber but currently assigned to $currentDeviceAssigned -- resolving"
-            )
-            avoidProbeIdConflict(currentDeviceAssigned, probeId)
-        }
+    fun hasProbeIdConflict(probeSerialNumber: String, probeId: ProbeID): Boolean {
+        val currentDeviceForProbeId = knownProbeIdAssignedToDevice[probeId]
+        return (currentDeviceForProbeId != null) && (currentDeviceForProbeId != probeSerialNumber)
     }
 
     fun addDevice(probeSerialNumber: String, manager: ProbeManager) {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
@@ -48,7 +48,7 @@ internal class ProbeIdManager(
 
     val availableProbeIds: Flow<List<ProbeID>> =
         knownProbeIdAssignedToDevice.stateFlow.map { map ->
-            ProbeID.entries.filterNot { map.keys.contains(it) }
+            ProbeID.entries.filterNot { it in map }
         }
 
     private fun findLowestAvailableProbeId(exceptConflictId: ProbeID): ProbeID? {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
@@ -58,11 +58,7 @@ internal class ProbeIdManager(
     }
 
     private fun removeProbeIdAssignmentsToDevice(serialNumber: String, except: ProbeID?) {
-        return ProbeID.entries.forEach {
-            if ((it != except) && (knownProbeIdAssignedToDevice[it] == serialNumber)) {
-                knownProbeIdAssignedToDevice.remove(it)
-            }
-        }
+        knownProbeIdAssignedToDevice.removeIf { it.key != except && it.value == serialNumber }
     }
 
     private fun resolveProbeIdConflict(
@@ -133,6 +129,7 @@ internal class ProbeIdManager(
     }
 
     fun addDevice(probeSerialNumber: String, manager: ProbeManager) {
+        probeIdObservations.remove(probeSerialNumber)?.cancel()
         probeIdObservations[probeSerialNumber] = scope.launch {
             manager.deviceFlow
                 .filter {

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeIdManager.kt
@@ -46,7 +46,7 @@ internal class ProbeIdManager(
 ) {
     private val probeIdObservations = ConcurrentHashMap<String, Job>()
 
-    val availableProbeIds: Flow<List<ProbeID>> =
+    val availableProbeIDs: Flow<List<ProbeID>> =
         knownProbeIdAssignedToDevice.stateFlow.map { map ->
             ProbeID.entries.filterNot { it in map }
         }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionProductType.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/CombustionProductType.kt
@@ -66,7 +66,7 @@ enum class CombustionProductType(val type: UByte) {
             when (productType) {
                 DfuProductType.PROBE -> PROBE
                 DfuProductType.GAUGE -> GAUGE
-                DfuProductType.CHARGER, DfuProductType.CHARGER -> NODE
+                DfuProductType.CHARGER, DfuProductType.DISPLAY -> NODE
                 else -> UNKNOWN
             }
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -475,6 +475,19 @@ class DeviceManager(
                 started = SharingStarted.Lazily,
             )
 
+    /**
+     * Observe ProbeIDs that are not currently assigned to an active device.
+     */
+    val availableProbeIDs: StateFlow<List<ProbeID>> = NetworkManager.instanceFlow
+        .flatMapLatest { mgr ->
+            mgr?.availableProbeIDs ?: flowOf(ProbeID.entries)
+        }
+        .stateIn(
+            scope = appApiScope,
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+            initialValue = ProbeID.entries,
+        )
+
     private fun doWhenNetworkManagerInitialized(onInitialized: suspend (NetworkManager) -> Unit) {
         appApiScope.launch {
             NetworkManager.instanceFlow.first { it != null }?.let {

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/ble/ProbeIdManagerTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/ble/ProbeIdManagerTest.kt
@@ -1,0 +1,275 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: ProbeIdManagerTest.kt
+ * Author:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2026. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework.ble
+
+import android.util.Log
+import inc.combustion.framework.service.Probe
+import inc.combustion.framework.service.ProbeID
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProbeIdManagerTest {
+
+    private val setProbeID: (String, ProbeID, (Boolean) -> Unit) -> Unit = mockk()
+
+    @Before
+    fun setup() {
+        mockkStatic(Log::class)
+        every { Log.v(any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.e(any(), any()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    private fun mockProbe(id: ProbeID?, isPlaceholder: Boolean): Probe {
+        val probe = mockk<Probe>(relaxed = true)
+        every { probe.id } returns id
+        every { probe.isPlaceholder() } returns isPlaceholder
+        return probe
+    }
+
+    @Test
+    fun `availableProbeIDs should initially contain all IDs`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val available = probeIdManager.availableProbeIDs.first()
+        assertEquals(ProbeID.entries.toList(), available)
+    }
+
+    @Test
+    fun `adding a device should update availableProbeIDs`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val serial = "ABC1"
+        val probeManager = mockk<ProbeManager>()
+        val probe = mockProbe(ProbeID.ID1, isPlaceholder = false)
+        
+        val deviceFlow = MutableStateFlow(probe)
+        every { probeManager.deviceFlow } returns deviceFlow
+
+        probeIdManager.addDevice(serial, probeManager)
+        
+        // Wait for ID1 to disappear from available IDs
+        val available = probeIdManager.availableProbeIDs
+            .filter { !it.contains(ProbeID.ID1) }
+            .first()
+            
+        assertFalse("ID1 should not be available", available.contains(ProbeID.ID1))
+        assertTrue("ID2 should be available", available.contains(ProbeID.ID2))
+    }
+
+    @Test
+    fun `addDevice should ignore placeholder devices`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val serial = "ABC1"
+        val probeManager = mockk<ProbeManager>()
+        val probe = mockProbe(ProbeID.ID1, isPlaceholder = true)
+        
+        val deviceFlow = MutableStateFlow(probe)
+        every { probeManager.deviceFlow } returns deviceFlow
+
+        probeIdManager.addDevice(serial, probeManager)
+        advanceUntilIdle()
+
+        val available = probeIdManager.availableProbeIDs.first()
+        assertTrue("ID1 should still be available because device was placeholder", available.contains(ProbeID.ID1))
+    }
+
+    @Test
+    fun `conflict resolution - higher serial gets lower ID`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val serialHigher = "00000014" // 20
+        val serialLower = "0000000A" // 10
+
+        val probeManagerLower = mockk<ProbeManager>()
+        val deviceFlowLower = MutableStateFlow(mockProbe(ProbeID.ID2, isPlaceholder = false))
+        every { probeManagerLower.deviceFlow } returns deviceFlowLower
+
+        val probeManagerHigher = mockk<ProbeManager>()
+        val deviceFlowHigher = MutableStateFlow(mockProbe(ProbeID.ID2, isPlaceholder = false))
+        every { probeManagerHigher.deviceFlow } returns deviceFlowHigher
+
+        // First device (Lower serial) joins and gets ID2
+        probeIdManager.addDevice(serialLower, probeManagerLower)
+        probeIdManager.availableProbeIDs.filter { !it.contains(ProbeID.ID2) }.first()
+
+        // Second device (Higher serial) joins and also wants ID2 -> Conflict
+        every { setProbeID(any(), any(), any()) } just runs
+
+        probeIdManager.addDevice(serialHigher, probeManagerHigher)
+        
+        // resolveProbeIdConflict will assign ID1 to Higher and ID2 to Lower
+        // We wait for ID1 to be taken as well
+        probeIdManager.availableProbeIDs.filter { !it.contains(ProbeID.ID1) }.first()
+
+        // Verify setProbeID calls
+        verify(exactly = 1) { setProbeID(serialHigher, ProbeID.ID1, any()) }
+        verify(exactly = 1) { setProbeID(serialLower, ProbeID.ID2, any()) }
+    }
+
+    @Test
+    fun `setProbeID failure should revert changes in map`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val serialHigher = "00000014"
+        val serialLower = "0000000A"
+
+        val probeManagerLower = mockk<ProbeManager>()
+        val deviceFlowLower = MutableStateFlow(mockProbe(ProbeID.ID2, isPlaceholder = false))
+        every { probeManagerLower.deviceFlow } returns deviceFlowLower
+
+        val probeManagerHigher = mockk<ProbeManager>()
+        val deviceFlowHigher = MutableStateFlow(mockProbe(ProbeID.ID2, isPlaceholder = false))
+        every { probeManagerHigher.deviceFlow } returns deviceFlowHigher
+
+        probeIdManager.addDevice(serialLower, probeManagerLower)
+        probeIdManager.availableProbeIDs.filter { !it.contains(ProbeID.ID2) }.first()
+
+        val callbackSlotHigher = slot<(Boolean) -> Unit>()
+        val callbackSlotLower = slot<(Boolean) -> Unit>()
+        every { setProbeID(serialHigher, ProbeID.ID1, capture(callbackSlotHigher)) } just runs
+        every { setProbeID(serialLower, ProbeID.ID2, capture(callbackSlotLower)) } just runs
+
+        probeIdManager.addDevice(serialHigher, probeManagerHigher)
+        probeIdManager.availableProbeIDs.filter { !it.contains(ProbeID.ID1) }.first()
+
+        // Simulate failure for higher serial
+        callbackSlotHigher.captured.invoke(false)
+        
+        // ID1 should now be available again
+        probeIdManager.availableProbeIDs.filter { it.contains(ProbeID.ID1) }.first()
+        
+        val available = probeIdManager.availableProbeIDs.first()
+        assertTrue(available.contains(ProbeID.ID1))
+        assertFalse(available.contains(ProbeID.ID2))
+    }
+
+    @Test
+    fun `removeDevice should cancel observation and clear assignments`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val serial = "ABC1"
+        val probeManager = mockk<ProbeManager>()
+        val probe = mockProbe(ProbeID.ID1, isPlaceholder = false)
+        val deviceFlow = MutableStateFlow(probe)
+        every { probeManager.deviceFlow } returns deviceFlow
+
+        probeIdManager.addDevice(serial, probeManager)
+        probeIdManager.availableProbeIDs.filter { !it.contains(ProbeID.ID1) }.first()
+
+        probeIdManager.removeDevice(serial)
+        probeIdManager.availableProbeIDs.filter { it.contains(ProbeID.ID1) }.first()
+
+        assertTrue(probeIdManager.availableProbeIDs.first().contains(ProbeID.ID1))
+
+        // Pushing a new ID to the flow should not update the manager anymore
+        deviceFlow.value = mockProbe(ProbeID.ID2, isPlaceholder = false)
+        advanceUntilIdle()
+
+        assertTrue(probeIdManager.availableProbeIDs.first().contains(ProbeID.ID2))
+    }
+
+    @Test
+    fun `clear should cancel all observations and clear all assignments`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val serial1 = "ABC1"
+        val serial2 = "ABC2"
+        val probeManager1 = mockk<ProbeManager>(relaxed = true)
+        val probeManager2 = mockk<ProbeManager>(relaxed = true)
+        
+        val deviceFlow1 = MutableStateFlow(mockProbe(ProbeID.ID1, isPlaceholder = false))
+        val deviceFlow2 = MutableStateFlow(mockProbe(ProbeID.ID2, isPlaceholder = false))
+        
+        every { probeManager1.deviceFlow } returns deviceFlow1
+        every { probeManager2.deviceFlow } returns deviceFlow2
+
+        probeIdManager.addDevice(serial1, probeManager1)
+        probeIdManager.addDevice(serial2, probeManager2)
+        
+        probeIdManager.availableProbeIDs.filter { !it.contains(ProbeID.ID1) && !it.contains(ProbeID.ID2) }.first()
+
+        probeIdManager.clear()
+        probeIdManager.availableProbeIDs.filter { it.contains(ProbeID.ID1) && it.contains(ProbeID.ID2) }.first()
+
+        assertEquals(ProbeID.entries.toList(), probeIdManager.availableProbeIDs.first())
+    }
+
+    @Test
+    fun `hasProbeIdConflict returns true only if a DIFFERENT device has the ID`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val serial1 = "SERIAL1"
+        val serial2 = "SERIAL2"
+        val probeManager = mockk<ProbeManager>()
+        val deviceFlow = MutableStateFlow(mockProbe(ProbeID.ID1, isPlaceholder = false))
+        every { probeManager.deviceFlow } returns deviceFlow
+
+        probeIdManager.addDevice(serial1, probeManager)
+        probeIdManager.availableProbeIDs.filter { !it.contains(ProbeID.ID1) }.first()
+
+        assertTrue(probeIdManager.hasProbeIdConflict(serial2, ProbeID.ID1))
+        assertFalse(probeIdManager.hasProbeIdConflict(serial1, ProbeID.ID1))
+        assertFalse(probeIdManager.hasProbeIdConflict(serial2, ProbeID.ID2))
+    }
+    
+    @Test
+    fun `changing probe ID for same device removes old assignment`() = runTest {
+        val probeIdManager = ProbeIdManager(setProbeID, backgroundScope)
+        val serial = "ABC1"
+        val probeManager = mockk<ProbeManager>()
+        val deviceFlow = MutableStateFlow(mockProbe(ProbeID.ID1, isPlaceholder = false))
+        every { probeManager.deviceFlow } returns deviceFlow
+
+        probeIdManager.addDevice(serial, probeManager)
+        probeIdManager.availableProbeIDs.filter { !it.contains(ProbeID.ID1) }.first()
+
+        // Change ID to ID2
+        deviceFlow.value = mockProbe(ProbeID.ID2, isPlaceholder = false)
+        
+        // Wait for ID2 to be taken and ID1 to be released
+        val available = probeIdManager.availableProbeIDs
+            .filter { it.contains(ProbeID.ID1) && !it.contains(ProbeID.ID2) }
+            .first()
+
+        assertTrue("Old ID1 should be available", available.contains(ProbeID.ID1))
+        assertFalse("New ID2 should be taken", available.contains(ProbeID.ID2))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ androidDesugarJdkLibs = "2.1.4"
 kotlinTestJunit = "2.1.0"
 mavenPublish = "0.25.3"
 mockk = "1.13.9"
+kotlinxCoroutines = "1.10.2"
 
 [libraries]
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "androidDesugarJdkLibs" }
@@ -33,6 +34,7 @@ kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit"
 nordicsemi-dfu = { group = "no.nordicsemi.android", name = "dfu", version.ref = "nordicsemiDfu" }
 junit-params = { group = "pl.pragmatists", name = "JUnitParams", version.ref = "junitParams" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
## Description
Implemented requirement changes:
1. only resolve observed conflicts
2. resolve conflict by assigning lowest ID to highest serialNr
3. If there is a conflict but no free IDs — do nothing
4. Don’t attempt to assign an ID to a device if ID is known to be used by a  different device (manufacture a collision)