### PR TITLE
DROID-757 : export CSV updates and other fixes

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/Extensions.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/Extensions.kt
@@ -49,8 +49,12 @@ fun UByte.setBit(bit: Int): UByte {
 
 fun UByte.toPercentage(): Int = this.toInt()
 
-fun UByteArray.utf8StringFromRange(indices: IntRange): String =
-    String(this.copyOf().sliceArray(indices).toByteArray(), Charsets.UTF_8).uppercase()
+// These are fixed-width fields; firmware pads them with trailing NUL bytes when the actual
+// string is shorter than the field width, so we trim those before returning.
+fun UByteArray.utf8StringFromRange(indices: IntRange, uppercase: Boolean = true): String =
+    String(this.copyOf().sliceArray(indices).toByteArray(), Charsets.UTF_8)
+        .trim('\u0000')
+        .let { if (uppercase) it.uppercase() else it }
 
 fun UByteArray.getUtf8SerialNumber(startIdx: Int): String =
     this.utf8StringFromRange(startIdx until (startIdx + UTF8_SERIAL_NUMBER_LENGTH))

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -57,11 +57,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
+
+private const val CSV_VERSION = 6
+private const val DEFAULT_SAMPLE_PERIOD: UInt = 5000u
 
 /**
  * Singleton instance for managing communications with Combustion Inc. devices.
@@ -797,16 +802,26 @@ class DeviceManager(
      *
      * @param serialNumber Serial number to export
      * @param appNameAndVersion Name and version to include in the CSV header
+     * @param sessionNotes Notes to include in the CSV, keyed by [LoggedDataPoint.sequenceNumber].
+     * The caller is responsible for matching notes to sequence numbers (e.g. by timestamp) and
+     * for ensuring each value is already CSV-safe: this function does not escape commas, quotes,
+     * or newlines, so values must not contain them unless already escaped per RFC 4180.
      * @return Pair: first is suggested name for the exported file, second is the CSV data.
      */
     fun exportLogsForDeviceAsCsv(
         serialNumber: String,
-        appNameAndVersion: String
+        appNameAndVersion: String,
+        sessionNotes: Map<UInt, String> = emptyMap(),
     ): Pair<String, String> {
-        val logs = exportLogsForProbe(serialNumber)
-        val probe = probe(serialNumber)
-
-        return probeDataToCsv(probe, logs, appNameAndVersion)
+        val gauge = gauge(serialNumber)
+        return if (gauge != null) {
+            val logs = exportLogsForGauge(serialNumber)
+            gaugeDataToCsv(gauge, logs, appNameAndVersion, sessionNotes)
+        } else {
+            val probe = probe(serialNumber)
+            val logs = exportLogsForProbe(serialNumber)
+            probeDataToCsv(probe, logs, appNameAndVersion, sessionNotes)
+        }
     }
 
     /**
@@ -1143,23 +1158,33 @@ class DeviceManager(
         }
     }
 
+    /**
+     * @param sessionNotes notes keyed by sequence number; values must already be CSV-safe (see
+     * [exportLogsForDeviceAsCsv]).
+     */
     private fun probeDataToCsv(
         probe: Probe?,
         probeData: List<LoggedProbeDataPoint>?,
         appNameAndVersion: String,
+        sessionNotes: Map<UInt, String> = emptyMap(),
     ): Pair<String, String> {
-        val csvVersion = 4
+        val csvVersion = CSV_VERSION
         val sb = StringBuilder()
         val serialNumber = probe?.serialNumber ?: "UNKNOWN"
         val firmwareVersion = probe?.fwVersion ?: "UNKNOWN"
         val hardwareVersion = probe?.hwRevision ?: "UNKNOWN"
-        val samplePeriod = probe?.sessionInfo?.samplePeriod ?: 0
+        val samplePeriod = probe?.sessionInfo?.samplePeriod ?: DEFAULT_SAMPLE_PERIOD
         val frameworkVersion =
             "Android ${Combustion.FRAMEWORK_VERSION_NAME} ${Combustion.FRAMEWORK_BUILD_TYPE}"
 
         val now = LocalDateTime.now()
         val headerDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
         val createdDateTime = now.format(headerDateTimeFormatter)
+
+        val startTime = (probeData?.firstOrNull()?.timestamp ?: Date()).time
+        val formattedStartTime =
+            LocalDateTime.ofInstant(Instant.ofEpochMilli(startTime), ZoneId.systemDefault())
+                .format(headerDateTimeFormatter)
 
         // header
         sb.appendLine("Combustion Inc. Probe Data")
@@ -1170,21 +1195,21 @@ class DeviceManager(
         sb.appendLine("Probe HW revision: $hardwareVersion")
         sb.appendLine("Framework: $frameworkVersion")
         sb.appendLine("Sample Period: $samplePeriod")
-        sb.appendLine("Created: $createdDateTime")
+        sb.appendLine("CSV Creation Date: $createdDateTime")
+        sb.appendLine("Session Start Date: $formattedStartTime")
         sb.appendLine()
 
         // column headers
-        sb.appendLine("Timestamp,SessionID,SequenceNumber,T1,T2,T3,T4,T5,T6,T7,T8,VirtualCoreTemperature,VirtualSurfaceTemperature,VirtualAmbientTemperature,EstimatedCoreTemperature,PredictionSetPoint,VirtualCoreSensor,VirtualSurfaceSensor,VirtualAmbientSensor,PredictionState,PredictionMode,PredictionType,PredictionValueSeconds")
+        sb.appendLine("Timestamp,SessionID,SequenceNumber,T1,T2,T3,T4,T5,T6,T7,T8,VirtualCoreTemperature,VirtualSurfaceTemperature,VirtualAmbientTemperature,EstimatedCoreTemperature,PredictionSetPoint,VirtualCoreSensor,VirtualSurfaceSensor,VirtualAmbientSensor,PredictionState,PredictionMode,PredictionType,PredictionValueSeconds,Notes")
 
         // the data
-        val startTime = probeData?.first()?.timestamp?.time ?: 0
         probeData?.forEach { dataPoint ->
             val timestamp = dataPoint.timestamp.time
             val elapsed = (timestamp - startTime) / 1000.0f
             sb.appendLine(
                 String.format(
                     locale = Locale.US,
-                    "%.3f,%s,%s,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%s,%s,%s,%s,%s,%s,%d",
+                    "%.3f,%s,%s,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%s,%s,%s,%s,%s,%s,%d,%s",
                     elapsed,
                     dataPoint.sessionId.toString(),
                     dataPoint.sequenceNumber.toString(),
@@ -1207,7 +1232,8 @@ class DeviceManager(
                     dataPoint.predictionState.toString(),
                     dataPoint.predictionMode.toString(),
                     dataPoint.predictionType.toString(),
-                    dataPoint.predictionValueSeconds.toInt()
+                    dataPoint.predictionValueSeconds.toInt(),
+                    sessionNotes.get(dataPoint.sequenceNumber) ?: "",
                 )
             )
         }
@@ -1216,6 +1242,75 @@ class DeviceManager(
         val fileDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
         val recommendedFileName =
             "ProbeData_${serialNumber}_${now.format(fileDateTimeFormatter)}.csv"
+
+        return recommendedFileName to sb.toString()
+    }
+
+    /**
+     * @param sessionNotes notes keyed by sequence number; values must already be CSV-safe (see
+     * [exportLogsForDeviceAsCsv]).
+     */
+    private fun gaugeDataToCsv(
+        gauge: Gauge?,
+        gaugeData: List<LoggedGaugeDataPoint>?,
+        appNameAndVersion: String,
+        sessionNotes: Map<UInt, String> = emptyMap(),
+    ): Pair<String, String> {
+        val csvVersion = CSV_VERSION
+        val sb = StringBuilder()
+        val serialNumber = gauge?.serialNumber ?: "UNKNOWN"
+        val firmwareVersion = gauge?.fwVersion ?: "UNKNOWN"
+        val hardwareVersion = gauge?.hwRevision ?: "UNKNOWN"
+        val samplePeriod = gauge?.sessionInfo?.samplePeriod ?: DEFAULT_SAMPLE_PERIOD
+        val frameworkVersion =
+            "Android ${Combustion.FRAMEWORK_VERSION_NAME} ${Combustion.FRAMEWORK_BUILD_TYPE}"
+
+        val now = LocalDateTime.now()
+        val headerDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        val createdDateTime = now.format(headerDateTimeFormatter)
+
+        val startTime = (gaugeData?.firstOrNull()?.timestamp ?: Date()).time
+        val formattedStartTime =
+            LocalDateTime.ofInstant(Instant.ofEpochMilli(startTime), ZoneId.systemDefault())
+                .format(headerDateTimeFormatter)
+
+        // header
+        sb.appendLine("Combustion Inc. Gauge Data")
+        sb.appendLine("App: $appNameAndVersion")
+        sb.appendLine("CSV version: $csvVersion")
+        sb.appendLine("Gauge S/N: $serialNumber")
+        sb.appendLine("Gauge FW version: $firmwareVersion")
+        sb.appendLine("Gauge HW revision: $hardwareVersion")
+        sb.appendLine("Framework: $frameworkVersion")
+        sb.appendLine("Sample Period: $samplePeriod")
+        sb.appendLine("CSV Creation Date: $createdDateTime")
+        sb.appendLine("Session Start Date: $formattedStartTime")
+        sb.appendLine()
+
+        // column headers
+        sb.appendLine("Timestamp,SessionID,SequenceNumber,Temperature,Notes")
+
+        // the data
+        gaugeData?.forEach { dataPoint ->
+            val timestamp = dataPoint.timestamp.time
+            val elapsed = (timestamp - startTime) / 1000.0f
+            sb.appendLine(
+                String.format(
+                    locale = Locale.US,
+                    "%.3f,%s,%s,%.2f,%s",
+                    elapsed,
+                    dataPoint.sessionId.toString(),
+                    dataPoint.sequenceNumber.toString(),
+                    dataPoint.temperature.value,
+                    sessionNotes.get(dataPoint.sequenceNumber) ?: "",
+                )
+            )
+        }
+
+        // recommended file name
+        val fileDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+        val recommendedFileName =
+            "GaugeData_${serialNumber}_${now.format(fileDateTimeFormatter)}.csv"
 
         return recommendedFileName to sb.toString()
     }

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/service/DeviceManager.kt
@@ -1167,83 +1167,44 @@ class DeviceManager(
         probeData: List<LoggedProbeDataPoint>?,
         appNameAndVersion: String,
         sessionNotes: Map<UInt, String> = emptyMap(),
-    ): Pair<String, String> {
-        val csvVersion = CSV_VERSION
-        val sb = StringBuilder()
-        val serialNumber = probe?.serialNumber ?: "UNKNOWN"
-        val firmwareVersion = probe?.fwVersion ?: "UNKNOWN"
-        val hardwareVersion = probe?.hwRevision ?: "UNKNOWN"
-        val samplePeriod = probe?.sessionInfo?.samplePeriod ?: DEFAULT_SAMPLE_PERIOD
-        val frameworkVersion =
-            "Android ${Combustion.FRAMEWORK_VERSION_NAME} ${Combustion.FRAMEWORK_BUILD_TYPE}"
-
-        val now = LocalDateTime.now()
-        val headerDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-        val createdDateTime = now.format(headerDateTimeFormatter)
-
-        val startTime = (probeData?.firstOrNull()?.timestamp ?: Date()).time
-        val formattedStartTime =
-            LocalDateTime.ofInstant(Instant.ofEpochMilli(startTime), ZoneId.systemDefault())
-                .format(headerDateTimeFormatter)
-
-        // header
-        sb.appendLine("Combustion Inc. Probe Data")
-        sb.appendLine("App: $appNameAndVersion")
-        sb.appendLine("CSV version: $csvVersion")
-        sb.appendLine("Probe S/N: $serialNumber")
-        sb.appendLine("Probe FW version: $firmwareVersion")
-        sb.appendLine("Probe HW revision: $hardwareVersion")
-        sb.appendLine("Framework: $frameworkVersion")
-        sb.appendLine("Sample Period: $samplePeriod")
-        sb.appendLine("CSV Creation Date: $createdDateTime")
-        sb.appendLine("Session Start Date: $formattedStartTime")
-        sb.appendLine()
-
-        // column headers
-        sb.appendLine("Timestamp,SessionID,SequenceNumber,T1,T2,T3,T4,T5,T6,T7,T8,VirtualCoreTemperature,VirtualSurfaceTemperature,VirtualAmbientTemperature,EstimatedCoreTemperature,PredictionSetPoint,VirtualCoreSensor,VirtualSurfaceSensor,VirtualAmbientSensor,PredictionState,PredictionMode,PredictionType,PredictionValueSeconds,Notes")
-
-        // the data
-        probeData?.forEach { dataPoint ->
-            val timestamp = dataPoint.timestamp.time
-            val elapsed = (timestamp - startTime) / 1000.0f
-            sb.appendLine(
-                String.format(
-                    locale = Locale.US,
-                    "%.3f,%s,%s,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%s,%s,%s,%s,%s,%s,%d,%s",
-                    elapsed,
-                    dataPoint.sessionId.toString(),
-                    dataPoint.sequenceNumber.toString(),
-                    dataPoint.temperatures.values[0],
-                    dataPoint.temperatures.values[1],
-                    dataPoint.temperatures.values[2],
-                    dataPoint.temperatures.values[3],
-                    dataPoint.temperatures.values[4],
-                    dataPoint.temperatures.values[5],
-                    dataPoint.temperatures.values[6],
-                    dataPoint.temperatures.values[7],
-                    dataPoint.virtualCoreTemperature,
-                    dataPoint.virtualSurfaceTemperature,
-                    dataPoint.virtualAmbientTemperature,
-                    dataPoint.estimatedCoreTemperature,
-                    dataPoint.predictionSetPointTemperature,
-                    dataPoint.virtualCoreSensor.toString(),
-                    dataPoint.virtualSurfaceSensor.toString(),
-                    dataPoint.virtualAmbientSensor.toString(),
-                    dataPoint.predictionState.toString(),
-                    dataPoint.predictionMode.toString(),
-                    dataPoint.predictionType.toString(),
-                    dataPoint.predictionValueSeconds.toInt(),
-                    sessionNotes.get(dataPoint.sequenceNumber) ?: "",
-                )
-            )
-        }
-
-        // recommended file name
-        val fileDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
-        val recommendedFileName =
-            "ProbeData_${serialNumber}_${now.format(fileDateTimeFormatter)}.csv"
-
-        return recommendedFileName to sb.toString()
+    ): Pair<String, String> = deviceDataToCsv(
+        deviceLabel = "Probe",
+        serialNumber = probe?.serialNumber ?: "UNKNOWN",
+        firmwareVersion = probe?.fwVersion?.toString() ?: "UNKNOWN",
+        hardwareVersion = probe?.hwRevision ?: "UNKNOWN",
+        samplePeriod = probe?.sessionInfo?.samplePeriod ?: DEFAULT_SAMPLE_PERIOD,
+        appNameAndVersion = appNameAndVersion,
+        data = probeData,
+        columnHeaderLine = "Timestamp,SessionID,SequenceNumber,T1,T2,T3,T4,T5,T6,T7,T8,VirtualCoreTemperature,VirtualSurfaceTemperature,VirtualAmbientTemperature,EstimatedCoreTemperature,PredictionSetPoint,VirtualCoreSensor,VirtualSurfaceSensor,VirtualAmbientSensor,PredictionState,PredictionMode,PredictionType,PredictionValueSeconds,Notes",
+    ) { dataPoint, elapsed ->
+        String.format(
+            locale = Locale.US,
+            "%.3f,%s,%s,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%s,%s,%s,%s,%s,%s,%d,%s",
+            elapsed,
+            dataPoint.sessionId.toString(),
+            dataPoint.sequenceNumber.toString(),
+            dataPoint.temperatures.values[0],
+            dataPoint.temperatures.values[1],
+            dataPoint.temperatures.values[2],
+            dataPoint.temperatures.values[3],
+            dataPoint.temperatures.values[4],
+            dataPoint.temperatures.values[5],
+            dataPoint.temperatures.values[6],
+            dataPoint.temperatures.values[7],
+            dataPoint.virtualCoreTemperature,
+            dataPoint.virtualSurfaceTemperature,
+            dataPoint.virtualAmbientTemperature,
+            dataPoint.estimatedCoreTemperature,
+            dataPoint.predictionSetPointTemperature,
+            dataPoint.virtualCoreSensor.toString(),
+            dataPoint.virtualSurfaceSensor.toString(),
+            dataPoint.virtualAmbientSensor.toString(),
+            dataPoint.predictionState.toString(),
+            dataPoint.predictionMode.toString(),
+            dataPoint.predictionType.toString(),
+            dataPoint.predictionValueSeconds.toInt(),
+            sessionNotes[dataPoint.sequenceNumber] ?: "",
+        )
     }
 
     /**
@@ -1255,13 +1216,44 @@ class DeviceManager(
         gaugeData: List<LoggedGaugeDataPoint>?,
         appNameAndVersion: String,
         sessionNotes: Map<UInt, String> = emptyMap(),
+    ): Pair<String, String> = deviceDataToCsv(
+        deviceLabel = "Gauge",
+        serialNumber = gauge?.serialNumber ?: "UNKNOWN",
+        firmwareVersion = gauge?.fwVersion?.toString() ?: "UNKNOWN",
+        hardwareVersion = gauge?.hwRevision ?: "UNKNOWN",
+        samplePeriod = gauge?.sessionInfo?.samplePeriod ?: DEFAULT_SAMPLE_PERIOD,
+        appNameAndVersion = appNameAndVersion,
+        data = gaugeData,
+        columnHeaderLine = "Timestamp,SessionID,SequenceNumber,Temperature,Notes",
+    ) { dataPoint, elapsed ->
+        String.format(
+            locale = Locale.US,
+            "%.3f,%s,%s,%.2f,%s",
+            elapsed,
+            dataPoint.sessionId.toString(),
+            dataPoint.sequenceNumber.toString(),
+            dataPoint.temperature.value,
+            sessionNotes[dataPoint.sequenceNumber] ?: "",
+        )
+    }
+
+    /**
+     * Shared CSV-building logic for [probeDataToCsv] and [gaugeDataToCsv]: writes the common
+     * header block, then the column header and one formatted row per data point produced by
+     * [formatRow].
+     */
+    private fun <T : LoggedDataPoint> deviceDataToCsv(
+        deviceLabel: String,
+        serialNumber: String,
+        firmwareVersion: String,
+        hardwareVersion: String,
+        samplePeriod: UInt,
+        appNameAndVersion: String,
+        data: List<T>?,
+        columnHeaderLine: String,
+        formatRow: (dataPoint: T, elapsedSeconds: Float) -> String,
     ): Pair<String, String> {
-        val csvVersion = CSV_VERSION
         val sb = StringBuilder()
-        val serialNumber = gauge?.serialNumber ?: "UNKNOWN"
-        val firmwareVersion = gauge?.fwVersion ?: "UNKNOWN"
-        val hardwareVersion = gauge?.hwRevision ?: "UNKNOWN"
-        val samplePeriod = gauge?.sessionInfo?.samplePeriod ?: DEFAULT_SAMPLE_PERIOD
         val frameworkVersion =
             "Android ${Combustion.FRAMEWORK_VERSION_NAME} ${Combustion.FRAMEWORK_BUILD_TYPE}"
 
@@ -1269,18 +1261,18 @@ class DeviceManager(
         val headerDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
         val createdDateTime = now.format(headerDateTimeFormatter)
 
-        val startTime = (gaugeData?.firstOrNull()?.timestamp ?: Date()).time
+        val startTime = (data?.firstOrNull()?.timestamp ?: Date()).time
         val formattedStartTime =
             LocalDateTime.ofInstant(Instant.ofEpochMilli(startTime), ZoneId.systemDefault())
                 .format(headerDateTimeFormatter)
 
         // header
-        sb.appendLine("Combustion Inc. Gauge Data")
+        sb.appendLine("Combustion Inc. $deviceLabel Data")
         sb.appendLine("App: $appNameAndVersion")
-        sb.appendLine("CSV version: $csvVersion")
-        sb.appendLine("Gauge S/N: $serialNumber")
-        sb.appendLine("Gauge FW version: $firmwareVersion")
-        sb.appendLine("Gauge HW revision: $hardwareVersion")
+        sb.appendLine("CSV version: $CSV_VERSION")
+        sb.appendLine("$deviceLabel S/N: $serialNumber")
+        sb.appendLine("$deviceLabel FW version: $firmwareVersion")
+        sb.appendLine("$deviceLabel HW revision: $hardwareVersion")
         sb.appendLine("Framework: $frameworkVersion")
         sb.appendLine("Sample Period: $samplePeriod")
         sb.appendLine("CSV Creation Date: $createdDateTime")
@@ -1288,29 +1280,18 @@ class DeviceManager(
         sb.appendLine()
 
         // column headers
-        sb.appendLine("Timestamp,SessionID,SequenceNumber,Temperature,Notes")
+        sb.appendLine(columnHeaderLine)
 
         // the data
-        gaugeData?.forEach { dataPoint ->
-            val timestamp = dataPoint.timestamp.time
-            val elapsed = (timestamp - startTime) / 1000.0f
-            sb.appendLine(
-                String.format(
-                    locale = Locale.US,
-                    "%.3f,%s,%s,%.2f,%s",
-                    elapsed,
-                    dataPoint.sessionId.toString(),
-                    dataPoint.sequenceNumber.toString(),
-                    dataPoint.temperature.value,
-                    sessionNotes.get(dataPoint.sequenceNumber) ?: "",
-                )
-            )
+        data?.forEach { dataPoint ->
+            val elapsed = (dataPoint.timestamp.time - startTime) / 1000.0f
+            sb.appendLine(formatRow(dataPoint, elapsed))
         }
 
         // recommended file name
         val fileDateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
         val recommendedFileName =
-            "GaugeData_${serialNumber}_${now.format(fileDateTimeFormatter)}.csv"
+            "${deviceLabel}Data_${serialNumber}_${now.format(fileDateTimeFormatter)}.csv"
 
         return recommendedFileName to sb.toString()
     }

--- a/combustion-android-ble/src/test/java/inc/combustion/framework/ExtensionsTest.kt
+++ b/combustion-android-ble/src/test/java/inc/combustion/framework/ExtensionsTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Project: Combustion Inc. Android Framework
+ * File: ExtensionsTest.kt
+ * Author:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2026. Combustion Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package inc.combustion.framework
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalUnsignedTypes::class)
+class ExtensionsTest {
+    @Test
+    fun `utf8StringFromRange trims a single trailing null byte`() {
+        val bytes = "GGG198A54".toByteArray(Charsets.UTF_8).toUByteArray() + ubyteArrayOf(0u)
+
+        assertEquals("GGG198A54", bytes.utf8StringFromRange(bytes.indices))
+    }
+
+    @Test
+    fun `utf8StringFromRange trims multiple trailing null bytes`() {
+        val bytes = "AB".toByteArray(Charsets.UTF_8).toUByteArray() + ubyteArrayOf(0u, 0u, 0u)
+
+        assertEquals("AB", bytes.utf8StringFromRange(bytes.indices))
+    }
+
+    @Test
+    fun `utf8StringFromRange leaves a string that exactly fills the field unchanged`() {
+        val bytes = "1234567890".toByteArray(Charsets.UTF_8).toUByteArray()
+
+        assertEquals("1234567890", bytes.utf8StringFromRange(bytes.indices))
+    }
+
+    @Test
+    fun `utf8StringFromRange only reads the requested range`() {
+        val bytes = "XXGGG198A54YY".toByteArray(Charsets.UTF_8).toUByteArray()
+
+        assertEquals("GGG198A54", bytes.utf8StringFromRange(2..10))
+    }
+
+    @Test
+    fun `utf8StringFromRange uppercases by default`() {
+        val bytes = "abc123".toByteArray(Charsets.UTF_8).toUByteArray() + ubyteArrayOf(0u)
+
+        assertEquals("ABC123", bytes.utf8StringFromRange(bytes.indices))
+    }
+
+    @Test
+    fun `utf8StringFromRange preserves case when uppercase is false`() {
+        val bytes = "v1.2.3".toByteArray(Charsets.UTF_8).toUByteArray() + ubyteArrayOf(0u)
+
+        assertEquals("v1.2.3", bytes.utf8StringFromRange(bytes.indices, uppercase = false))
+    }
+}


### PR DESCRIPTION
## Description
- update csv export:
    - support gauge
    - add session start date to header
    - add a notes column
    - update version to 6
- Trim trailing null-byte padding from fixed-width UTF-8 fields: Fixed-width fields (serial numbers, hardware/firmware revision) are null-padded by firmware when the string is shorter than the field width -- utf8StringFromRange() didn't strip that padding. companion app PR: https://github.com/combustion-inc/combustion-android-prod/pull/418

### Note, app uses its own export and not framework's since framework is limited to ble data.