### PR TITLE
v3.5.1 bugs

### DIFF
--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeDataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeDataLinkArbitrator.kt
@@ -399,6 +399,14 @@ internal class ProbeDataLinkArbitrator(
             currentStatus = status
         }
 
+        Log.v(
+            LOG_TAG,
+            "shouldUpdateDataFromStatusForNormalMode: " +
+                "${(bleDevice ?: repeatedProbeBleDevices.firstOrNull())?.serialNumber} " +
+                "shouldUpdate=$shouldUpdate currentSessionInfo=$currentSessionInfo sessionInfo=$sessionInfo " +
+                "currentMax=${currentStatus?.maxSequenceNumber} newMax=${status.maxSequenceNumber}"
+        )
+
         return shouldUpdate
     }
 

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeDataLinkArbitrator.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeDataLinkArbitrator.kt
@@ -40,6 +40,7 @@ import inc.combustion.framework.service.DeviceManager
 import inc.combustion.framework.service.ProbeMode
 import inc.combustion.framework.service.SessionInformation
 import inc.combustion.framework.service.utils.ConcurrentSnapshotMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 // Number of seconds to ignore other lower-priority (higher hop count) sources of information for Instant Read
 private const val INSTANT_READ_IDLE_TIMEOUT = 1000L
@@ -60,8 +61,11 @@ internal class ProbeDataLinkArbitrator(
     override var bleDevice: ProbeBleDeviceBase? = null
         private set
 
-    // meatnet links to probe
-    val repeatedProbeBleDevices = mutableListOf<RepeatedProbeBleDevice>()
+    // meatnet links to probe -- CopyOnWriteArrayList because this is written from device
+    // connect/disconnect callbacks while concurrently being iterated (e.g. from connection-state
+    // handling) on other threads; a plain ArrayList here caused a fatal
+    // ConcurrentModificationException in meatNetIsOutOfRange.
+    val repeatedProbeBleDevices: MutableList<RepeatedProbeBleDevice> = CopyOnWriteArrayList()
 
     // probe discovery timestamp
     override var directLinkDiscoverTimestamp: Long? = null

--- a/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
+++ b/combustion-android-ble/src/main/java/inc/combustion/framework/ble/ProbeManager.kt
@@ -1063,6 +1063,7 @@ internal class ProbeManager(
     }
 
     private suspend fun handleProbeStatus(status: ProbeStatus, hopCount: UInt?) {
+        Log.v(LOG_TAG, "ProbeManager.handleProbeStatus RECEIVED: $serialNumber $status")
         handleStatusMutex.withLock {
             if (arbitrator.shouldUpdateDataFromStatus(status, sessionInfo, hopCount)) {
                 Log.v(LOG_TAG, "ProbeManager.handleProbeStatus: $serialNumber $status")


### PR DESCRIPTION
## Desription
- Fix ConcurrentModificationException in ProbeDataLinkArbitrator.meatNetIsOutOfRange from [firebase](https://console.firebase.google.com/project/combustion-dev-apps/crashlytics/app/android:inc.combustion.app.dev/issues/0478b42f4b8384aac4cdf22ecb6d37f2?time=24h&types=crash)
- Add logs to solve device reported stuck in cloud mode. Filter logs on "Combustion.Probe" and see commit message for decision tree 
